### PR TITLE
feat(dashboard): Insights 페이지 + 서비스 홈 네비게이션 (PR1/3)

### DIFF
--- a/app/api/v1/endpoints/dashboard.py
+++ b/app/api/v1/endpoints/dashboard.py
@@ -13,6 +13,7 @@ from ....core.config import settings, APP_VERSION
 from ....core.database import get_db
 from ....models.report import ReportType, ReportStatus
 from ....models.issue import WorkItem, ItemCategory, ItemStatus
+from ....models.insight import Newsletter, IngestionEvent
 from ....services.report_service import get_report_service
 from ....services.stats_service import get_stats_service
 from ....services.dev_plan_service import get_dev_plan_service
@@ -438,4 +439,56 @@ def project_detail(
         all_items=all_items,
         current_period=period_type,
         active_page="projects",
+    )
+
+
+@router.get("/insights", response_class=HTMLResponse)
+def insights_page(
+    severity: str = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+):
+    """Insight 뉴스레터 타임라인 (PR1: 섹션 ① 주차별 Tech Digest)"""
+    from sqlalchemy import select
+
+    nl_q = select(Newsletter).order_by(Newsletter.created_at.desc()).limit(limit)
+    newsletters = db.scalars(nl_q).all()
+
+    # 각 뉴스레터의 source 이벤트 severity 분포 집계
+    cards = []
+    for nl in newsletters:
+        sev_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "other": 0}
+        if nl.source_event_ids:
+            ev_rows = db.scalars(
+                select(IngestionEvent.severity).where(
+                    IngestionEvent.id.in_(nl.source_event_ids)
+                )
+            ).all()
+            for sev in ev_rows:
+                key = (sev or "other").lower()
+                if key not in sev_counts:
+                    key = "other"
+                sev_counts[key] += 1
+        cards.append({
+            "id": str(nl.id),
+            "period_start": nl.period_start,
+            "period_end": nl.period_end,
+            "headline": nl.headline,
+            "subject": nl.subject,
+            "created_at": nl.created_at,
+            "sent_at": nl.sent_at,
+            "source_count": len(nl.source_event_ids or []),
+            "kpis": nl.kpis or {},
+            "sev_counts": sev_counts,
+        })
+
+    # severity 필터 적용 (해당 severity 가 1건 이상인 카드만)
+    if severity in ("critical", "high", "medium", "low"):
+        cards = [c for c in cards if c["sev_counts"].get(severity, 0) > 0]
+
+    return _render(
+        "insights.html",
+        cards=cards,
+        current_severity=severity or "all",
+        active_page="insights",
     )

--- a/app/templates/dashboard/base.html
+++ b/app/templates/dashboard/base.html
@@ -57,6 +57,13 @@
         .sidebar-nav a:hover { color: #fff; background: #334155; }
         .sidebar-nav a.active { color: #fff; background: #2563eb; }
         .sidebar-nav a .icon { width: 18px; text-align: center; }
+        .sidebar-nav a.home-link {
+            color: #cbd5e1;
+            border-bottom: 1px solid #334155;
+            margin-bottom: 8px;
+            padding-bottom: 12px;
+        }
+        .sidebar-nav a.home-link:hover { color: #fff; background: #0f172a; }
 
         /* Main content */
         .main {
@@ -363,11 +370,14 @@
 </head>
 <body>
     <nav class="sidebar">
-        <div class="sidebar-brand">
+        <a href="{{ base_path }}/" class="sidebar-brand" style="text-decoration:none; display:block;">
             StandUp
             <small>v{{ app_version }}</small>
-        </div>
+        </a>
         <div class="sidebar-nav">
+            <a href="{{ base_path }}/" class="home-link">
+                <span class="icon">&#8962;</span> 서비스 홈
+            </a>
             <a href="{{ base_path }}/dashboard" class="{% if active_page == 'home' %}active{% endif %}">
                 <span class="icon">&#9776;</span> Dashboard
             </a>
@@ -382,6 +392,9 @@
             </a>
             <a href="{{ base_path }}/dashboard/dev-plans" class="{% if active_page == 'dev_plans' %}active{% endif %}">
                 <span class="icon">&#9881;</span> Dev Plans
+            </a>
+            <a href="{{ base_path }}/dashboard/insights" class="{% if active_page == 'insights' %}active{% endif %}">
+                <span class="icon">&#9678;</span> Insights
             </a>
             <a href="{{ base_path }}/dashboard/stats" class="{% if active_page == 'stats' %}active{% endif %}">
                 <span class="icon">&#9733;</span> Statistics

--- a/app/templates/dashboard/insights.html
+++ b/app/templates/dashboard/insights.html
@@ -1,0 +1,228 @@
+{% extends "base.html" %}
+
+{% block title %}StandUp - Insights{% endblock %}
+{% block page_title %}Insights{% endblock %}
+{% block page_meta %}주차별 Tech Digest 타임라인 · 토픽 클러스터 · HopenVision 적용 플랜{% endblock %}
+
+{% block content %}
+<style>
+    .ins-tabbar { margin-bottom: 20px; }
+    .ins-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+        gap: 16px;
+    }
+    .ins-card {
+        background: #fff;
+        border-radius: 8px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+        padding: 18px 20px;
+        transition: box-shadow 0.15s, transform 0.15s;
+        cursor: pointer;
+    }
+    .ins-card:hover {
+        box-shadow: 0 6px 16px rgba(0,0,0,0.1);
+        transform: translateY(-2px);
+    }
+    .ins-card .period {
+        font-size: 11px;
+        color: #94a3b8;
+        margin-bottom: 4px;
+    }
+    .ins-card .headline {
+        font-size: 14px;
+        font-weight: 600;
+        color: #1e293b;
+        line-height: 1.5;
+        margin-bottom: 12px;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+    .ins-sev-bar {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin-bottom: 10px;
+    }
+    .ins-sev {
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 10px;
+        font-weight: 600;
+    }
+    .ins-sev-critical { background: #ffebe9; color: #cf222e; }
+    .ins-sev-high     { background: #fff8c5; color: #9a6700; }
+    .ins-sev-medium   { background: #ddf4ff; color: #0969da; }
+    .ins-sev-low      { background: #dafbe1; color: #1a7f37; }
+    .ins-sev-other    { background: #f1f5f9; color: #64748b; }
+    .ins-meta-row {
+        display: flex;
+        justify-content: space-between;
+        font-size: 11px;
+        color: #64748b;
+        border-top: 1px solid #f1f5f9;
+        padding-top: 8px;
+    }
+    .ins-meta-row .sent { color: #16a34a; font-weight: 600; }
+    .ins-meta-row .pending { color: #d97706; font-weight: 600; }
+
+    /* Modal preview */
+    .ins-modal-bg {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(15,23,42,0.55);
+        z-index: 1000;
+        align-items: center;
+        justify-content: center;
+    }
+    .ins-modal-bg.show { display: flex; }
+    .ins-modal {
+        background: #fff;
+        border-radius: 10px;
+        width: min(900px, 92vw);
+        height: min(85vh, 800px);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+    .ins-modal-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 14px 20px;
+        border-bottom: 1px solid #e2e8f0;
+        background: #f8fafc;
+    }
+    .ins-modal-head h3 { font-size: 14px; color: #1e293b; }
+    .ins-modal-close {
+        background: none;
+        border: none;
+        font-size: 22px;
+        cursor: pointer;
+        color: #64748b;
+        line-height: 1;
+    }
+    .ins-modal-close:hover { color: #1e293b; }
+    .ins-modal-body { flex: 1; overflow: hidden; }
+    .ins-modal-body iframe { width: 100%; height: 100%; border: none; }
+
+    .ins-empty {
+        text-align: center;
+        padding: 60px 20px;
+        color: #94a3b8;
+        font-size: 13px;
+    }
+
+    /* Section placeholders for PR2/PR3 */
+    .ins-future {
+        background: #f8fafc;
+        border: 1px dashed #cbd5e1;
+        border-radius: 8px;
+        padding: 24px;
+        text-align: center;
+        color: #64748b;
+        font-size: 13px;
+        margin-top: 24px;
+    }
+</style>
+
+<!-- Section ①: Weekly Tech Digest Timeline -->
+<div class="card-header" style="margin-bottom:12px;">
+    <h2 style="font-size:15px; color:#1e293b;">① 주차별 Tech Digest</h2>
+    <span style="font-size:12px; color:#94a3b8;">{{ cards | length }}건</span>
+</div>
+
+<!-- Severity filter tabs -->
+<div class="tab-bar ins-tabbar">
+    <a href="{{ base_path }}/dashboard/insights"
+       class="{% if current_severity == 'all' %}active{% endif %}">전체</a>
+    <a href="{{ base_path }}/dashboard/insights?severity=critical"
+       class="{% if current_severity == 'critical' %}active{% endif %}">Critical</a>
+    <a href="{{ base_path }}/dashboard/insights?severity=high"
+       class="{% if current_severity == 'high' %}active{% endif %}">High</a>
+    <a href="{{ base_path }}/dashboard/insights?severity=medium"
+       class="{% if current_severity == 'medium' %}active{% endif %}">Medium</a>
+    <a href="{{ base_path }}/dashboard/insights?severity=low"
+       class="{% if current_severity == 'low' %}active{% endif %}">Low</a>
+</div>
+
+{% if cards %}
+<div class="ins-grid">
+    {% for c in cards %}
+    <div class="ins-card" onclick="openPreview('{{ c.id }}', {{ c.headline | tojson }})">
+        <div class="period">
+            {{ c.period_start.strftime('%Y-%m-%d') }} ~ {{ c.period_end.strftime('%Y-%m-%d') }}
+        </div>
+        <div class="headline">{{ c.headline }}</div>
+        <div class="ins-sev-bar">
+            {% for sev in ['critical', 'high', 'medium', 'low', 'other'] %}
+            {% if c.sev_counts[sev] > 0 %}
+            <span class="ins-sev ins-sev-{{ sev }}">{{ sev }} {{ c.sev_counts[sev] }}</span>
+            {% endif %}
+            {% endfor %}
+        </div>
+        <div class="ins-meta-row">
+            <span>이벤트 {{ c.source_count }}건</span>
+            {% if c.sent_at %}
+            <span class="sent">발송 {{ c.sent_at.strftime('%m-%d %H:%M') }}</span>
+            {% else %}
+            <span class="pending">미발송</span>
+            {% endif %}
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<div class="ins-empty">
+    {% if current_severity != 'all' %}
+    선택한 severity({{ current_severity }})에 해당하는 뉴스레터가 없습니다.
+    {% else %}
+    아직 발송된 뉴스레터가 없습니다. <code>POST /api/v1/insight/weekly/run</code> 으로 즉시 생성할 수 있습니다.
+    {% endif %}
+</div>
+{% endif %}
+
+<!-- PR2 placeholder -->
+<div class="ins-future">
+    <strong>② 기술 토픽 클러스터</strong> — pgvector 임베딩 기반 토픽 카드 · PR2 작업 예정
+</div>
+
+<!-- PR3 placeholder -->
+<div class="ins-future">
+    <strong>③ HopenVision 적용 플랜 분석</strong> — 토픽 → LLM 적용 제안 → DevPlan 자동 초안 · PR3 작업 예정
+</div>
+
+<!-- Preview modal -->
+<div class="ins-modal-bg" id="insModalBg" onclick="if(event.target===this) closePreview()">
+    <div class="ins-modal">
+        <div class="ins-modal-head">
+            <h3 id="insModalTitle">뉴스레터 미리보기</h3>
+            <button class="ins-modal-close" onclick="closePreview()">&times;</button>
+        </div>
+        <div class="ins-modal-body">
+            <iframe id="insModalFrame" sandbox="allow-same-origin"></iframe>
+        </div>
+    </div>
+</div>
+
+<script>
+function openPreview(newsletterId, headline) {
+    document.getElementById('insModalTitle').textContent = headline || '뉴스레터 미리보기';
+    var frame = document.getElementById('insModalFrame');
+    frame.src = '{{ base_path }}/api/v1/insight/newsletters/' + newsletterId + '/preview';
+    document.getElementById('insModalBg').classList.add('show');
+    document.body.style.overflow = 'hidden';
+}
+function closePreview() {
+    document.getElementById('insModalBg').classList.remove('show');
+    document.getElementById('insModalFrame').src = 'about:blank';
+    document.body.style.overflow = '';
+}
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') closePreview();
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- 사이드바 브랜드를 `/`(서비스 홈) 링크로 변경하고 "서비스 홈" 항목 추가 (allergyinsight 와 동일하게 메인화면 복귀 가능)
- `/dashboard/insights` 라우트 신규: 주차별 Tech Digest 타임라인 — severity(critical/high/medium/low) 필터 + 뉴스레터 미리보기 모달
- `Insights` 사이드바 항목 추가 / PR2(토픽 클러스터)·PR3(HopenVision 적용 플랜) placeholder 포함

## 변경 파일
- `app/templates/dashboard/base.html` — 사이드바 nav 확장
- `app/api/v1/endpoints/dashboard.py` — `/dashboard/insights` 엔드포인트 (Newsletter + IngestionEvent severity 집계)
- `app/templates/dashboard/insights.html` — 신규

## 동작
- 카드 클릭 → 모달 iframe 에서 `/api/v1/insight/newsletters/{id}/preview` 렌더 (기존 엔드포인트 재사용, 신규 마이그레이션 없음)
- severity 필터: 해당 severity 이벤트가 1건 이상인 뉴스레터만 노출

## Test plan
- [ ] `/` 접속 → intro.html 정상
- [ ] `/dashboard` 사이드바에서 "서비스 홈" 클릭 → `/` 이동 확인
- [ ] 사이드바 브랜드("StandUp") 클릭도 `/` 이동 확인
- [ ] `/dashboard/insights` 접속 → 뉴스레터 카드 리스트 노출 (없으면 빈 상태 메시지)
- [ ] severity 탭 클릭 → 필터링 동작
- [ ] 카드 클릭 → 모달에서 본문 정상 렌더, ESC/X 닫기 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)