### PR TITLE
feat(insights): 기술 토픽 클러스터 섹션 (PR2/3)

### DIFF
--- a/app/api/v1/endpoints/dashboard.py
+++ b/app/api/v1/endpoints/dashboard.py
@@ -446,10 +446,12 @@ def project_detail(
 def insights_page(
     severity: str = Query(default=None),
     limit: int = Query(default=20, ge=1, le=100),
+    cluster_days: int = Query(default=30, ge=7, le=120),
     db: Session = Depends(get_db),
 ):
-    """Insight 뉴스레터 타임라인 (PR1: 섹션 ① 주차별 Tech Digest)"""
+    """Insight 통합 페이지 — ① Tech Digest + ② 토픽 클러스터 + (③ PR3 placeholder)"""
     from sqlalchemy import select
+    from ....services.topic_cluster_service import get_topic_clusters
 
     nl_q = select(Newsletter).order_by(Newsletter.created_at.desc()).limit(limit)
     newsletters = db.scalars(nl_q).all()
@@ -482,13 +484,30 @@ def insights_page(
             "sev_counts": sev_counts,
         })
 
-    # severity 필터 적용 (해당 severity 가 1건 이상인 카드만)
     if severity in ("critical", "high", "medium", "low"):
         cards = [c for c in cards if c["sev_counts"].get(severity, 0) > 0]
+
+    # 섹션 ② 토픽 클러스터
+    try:
+        topic_clusters = get_topic_clusters(db, days=cluster_days)
+    except Exception as exc:  # pgvector 미설치 / 데이터 없음 시 페이지는 유지
+        import logging
+        logging.getLogger(__name__).warning("topic clustering 실패: %s", exc)
+        topic_clusters = []
 
     return _render(
         "insights.html",
         cards=cards,
         current_severity=severity or "all",
+        topic_clusters=topic_clusters,
+        cluster_days=cluster_days,
         active_page="insights",
     )
+
+
+@router.get("/insights/topics/{cluster_key}/related", response_class=HTMLResponse)
+def insights_topic_related(cluster_key: str, db: Session = Depends(get_db)):
+    """HTMX 파셜: 클러스터 → 관련 과거 뉴스레터 청크."""
+    from ....services.topic_cluster_service import get_related_newsletters
+    related = get_related_newsletters(db, cluster_key, top_k=3)
+    return _render("partials/topic_related.html", related=related)

--- a/app/services/topic_cluster_service.py
+++ b/app/services/topic_cluster_service.py
@@ -1,0 +1,270 @@
+"""
+Topic Cluster Service — pgvector cosine 거리 기반 단순 클러스터링.
+
+- 최근 N일 ingestion 청크(corpus_qa/logs/fixes)를 가져와 pairwise <=> 거리로
+  threshold 미만 쌍을 union-find 로 묶는다.
+- 클러스터당 키워드(타이틀/카테고리 토큰 빈도) + 이벤트 메타 + 대표 청크 산출.
+- 외부 의존(numpy/sklearn) 없이 pgvector 의 SQL 연산자만 사용.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..models.insight import (
+    COLLECTION_QA, COLLECTION_LOGS, COLLECTION_FIXES, COLLECTION_NEWSLETTERS,
+)
+
+logger = logging.getLogger(__name__)
+
+# 한·영 stopword (TF 키워드 추출용)
+_STOP = {
+    # English
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "of", "to", "in", "for", "on", "at", "by", "and", "or", "with", "from",
+    "as", "that", "this", "it", "its", "but", "not", "have", "has", "had",
+    "do", "does", "did", "can", "could", "should", "would", "will", "may",
+    "error", "errors", "log", "logs", "issue", "issues",
+    # Korean (very short list — 자주 쓰이는 비-명사)
+    "있다", "없다", "있는", "없는", "이다", "되다", "되는", "위해", "위한",
+    "대한", "하지", "하는", "해서", "에서", "으로", "이는", "그리고", "또는",
+}
+
+_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_\-]{2,}|[가-힣]{2,}")
+
+
+def _tokenize(s: Optional[str]) -> list[str]:
+    if not s:
+        return []
+    out = []
+    for m in _TOKEN_RE.findall(s):
+        low = m.lower()
+        if low in _STOP:
+            continue
+        out.append(m if any(c.isupper() for c in m) else low)
+    return out
+
+
+def _top_keywords(texts: list[str], k: int = 5) -> list[str]:
+    counter: Counter[str] = Counter()
+    for t in texts:
+        counter.update(_tokenize(t))
+    return [w for w, _ in counter.most_common(k)]
+
+
+@dataclass
+class ClusterEvent:
+    event_id: str
+    title: Optional[str]
+    severity: Optional[str]
+    category: Optional[str]
+    service_tag: Optional[str]
+    source_type: Optional[str]
+    source_url: Optional[str]
+    occurred_at: datetime
+
+
+@dataclass
+class TopicCluster:
+    cluster_key: str  # 안정적인 클러스터 식별자 — 대표 chunk_id 사용
+    keywords: list[str]
+    event_count: int
+    chunk_count: int
+    first_seen: datetime
+    last_seen: datetime
+    severity_mix: dict[str, int]
+    events: list[ClusterEvent] = field(default_factory=list)
+
+
+def get_topic_clusters(
+    session: Session,
+    days: int = 30,
+    distance_threshold: float = 0.35,
+    min_cluster_size: int = 3,
+    max_clusters: int = 10,
+    max_chunks: int = 300,
+) -> list[TopicCluster]:
+    """최근 days 일 동안 수집된 이벤트 청크들을 cosine 거리로 단일-링크 클러스터링."""
+    fetch_sql = text("""
+        SELECT
+            c.id AS chunk_id,
+            c.event_id,
+            c.chunk_text,
+            e.title, e.category, e.severity, e.service_tag,
+            e.source_type, e.source_url, e.occurred_at
+        FROM newsletter_chunks c
+        JOIN ingestion_events e ON e.id = c.event_id
+        WHERE c.embedding IS NOT NULL
+          AND c.collection IN (:c_qa, :c_logs, :c_fixes)
+          AND e.occurred_at >= NOW() - make_interval(days => :days)
+        ORDER BY e.occurred_at DESC
+        LIMIT :limit
+    """)
+    rows = session.execute(fetch_sql, {
+        "c_qa": COLLECTION_QA,
+        "c_logs": COLLECTION_LOGS,
+        "c_fixes": COLLECTION_FIXES,
+        "days": days,
+        "limit": max_chunks,
+    }).mappings().all()
+
+    if len(rows) < min_cluster_size:
+        logger.info("topic_cluster: 청크 부족 — %d < min_size=%d", len(rows), min_cluster_size)
+        return []
+
+    chunk_ids = [r["chunk_id"] for r in rows]
+    by_id = {r["chunk_id"]: r for r in rows}
+
+    # pairwise distance — pgvector <=> 인덱스 활용
+    pair_sql = text("""
+        SELECT a.id AS a_id, b.id AS b_id,
+               (a.embedding <=> b.embedding) AS dist
+        FROM newsletter_chunks a
+        JOIN newsletter_chunks b ON a.id < b.id
+        WHERE a.id = ANY(:ids) AND b.id = ANY(:ids)
+          AND (a.embedding <=> b.embedding) < :threshold
+    """)
+    pairs = session.execute(pair_sql, {
+        "ids": chunk_ids,
+        "threshold": distance_threshold,
+    }).all()
+
+    # union-find
+    parent = {cid: cid for cid in chunk_ids}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for p in pairs:
+        union(p.a_id, p.b_id)
+
+    groups: dict[int, list[int]] = defaultdict(list)
+    for cid in chunk_ids:
+        groups[find(cid)].append(cid)
+
+    clusters: list[TopicCluster] = []
+    for root, member_ids in groups.items():
+        if len(member_ids) < min_cluster_size:
+            continue
+        member_rows = [by_id[m] for m in member_ids]
+
+        # 이벤트 dedup (한 이벤트가 여러 chunk 로 분할될 수 있음)
+        seen_events: dict[str, dict] = {}
+        for r in member_rows:
+            eid = str(r["event_id"]) if r["event_id"] else None
+            if eid and eid not in seen_events:
+                seen_events[eid] = r
+
+        if len(seen_events) < min_cluster_size:
+            continue
+
+        keywords = _top_keywords(
+            [r["title"] or "" for r in seen_events.values()] +
+            [r["category"] or "" for r in seen_events.values()] +
+            [r["service_tag"] or "" for r in seen_events.values()],
+            k=5,
+        )
+
+        sev_mix: Counter[str] = Counter()
+        for r in seen_events.values():
+            sev_mix[(r["severity"] or "other").lower()] += 1
+
+        events = sorted(
+            (ClusterEvent(
+                event_id=eid,
+                title=r["title"],
+                severity=r["severity"],
+                category=r["category"],
+                service_tag=r["service_tag"],
+                source_type=r["source_type"],
+                source_url=r["source_url"],
+                occurred_at=r["occurred_at"],
+            ) for eid, r in seen_events.items()),
+            key=lambda e: e.occurred_at,
+            reverse=True,
+        )
+
+        clusters.append(TopicCluster(
+            cluster_key=str(root),
+            keywords=keywords,
+            event_count=len(seen_events),
+            chunk_count=len(member_ids),
+            first_seen=min(e.occurred_at for e in events),
+            last_seen=max(e.occurred_at for e in events),
+            severity_mix=dict(sev_mix),
+            events=events,
+        ))
+
+    clusters.sort(key=lambda c: (c.event_count, c.last_seen), reverse=True)
+    return clusters[:max_clusters]
+
+
+@dataclass
+class RelatedNewsletter:
+    chunk_id: int
+    distance: float
+    headline: Optional[str]
+    period_start: Optional[str]
+    period_end: Optional[str]
+    excerpt: str
+
+
+def get_related_newsletters(
+    session: Session,
+    cluster_key: str,
+    top_k: int = 3,
+) -> list[RelatedNewsletter]:
+    """대표 chunk(=cluster_key) 임베딩으로 corpus_newsletters 유사 청크 top-k."""
+    try:
+        rep_id = int(cluster_key)
+    except ValueError:
+        return []
+
+    sql = text("""
+        WITH rep AS (
+            SELECT embedding FROM newsletter_chunks WHERE id = :rep_id
+        )
+        SELECT c.id, c.chunk_text, c.metadata_json, c.newsletter_id,
+               (c.embedding <=> rep.embedding) AS dist
+        FROM newsletter_chunks c, rep
+        WHERE c.collection = :coll
+          AND c.embedding IS NOT NULL
+          AND c.id <> :rep_id
+        ORDER BY c.embedding <=> rep.embedding
+        LIMIT :k
+    """)
+    rows = session.execute(sql, {
+        "rep_id": rep_id,
+        "coll": COLLECTION_NEWSLETTERS,
+        "k": top_k,
+    }).mappings().all()
+
+    out = []
+    for r in rows:
+        meta = r["metadata_json"] or {}
+        excerpt = (r["chunk_text"] or "")[:240].strip()
+        out.append(RelatedNewsletter(
+            chunk_id=r["id"],
+            distance=float(r["dist"]),
+            headline=meta.get("headline"),
+            period_start=meta.get("period_start"),
+            period_end=meta.get("period_end"),
+            excerpt=excerpt,
+        ))
+    return out

--- a/app/templates/dashboard/insights.html
+++ b/app/templates/dashboard/insights.html
@@ -185,10 +185,157 @@
 </div>
 {% endif %}
 
-<!-- PR2 placeholder -->
-<div class="ins-future">
-    <strong>② 기술 토픽 클러스터</strong> — pgvector 임베딩 기반 토픽 카드 · PR2 작업 예정
+<!-- Section ②: Tech Topic Clusters -->
+<div class="card-header" style="margin-top:32px; margin-bottom:12px;">
+    <h2 style="font-size:15px; color:#1e293b;">② 기술 토픽 클러스터</h2>
+    <span style="font-size:12px; color:#94a3b8;">최근 {{ cluster_days }}일 · {{ topic_clusters | length }}개 토픽</span>
 </div>
+
+<style>
+    .topic-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+        gap: 16px;
+    }
+    .topic-card {
+        background: #fff;
+        border-radius: 8px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+        padding: 16px 18px;
+    }
+    .topic-keywords { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
+    .topic-kw {
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 3px 10px;
+        border-radius: 12px;
+        font-size: 12px;
+        font-weight: 600;
+    }
+    .topic-kw:first-child {
+        background: #2563eb;
+        color: #fff;
+    }
+    .topic-meta {
+        display: flex;
+        gap: 12px;
+        font-size: 11px;
+        color: #64748b;
+        margin-bottom: 10px;
+    }
+    .topic-meta b { color: #1e293b; }
+    .topic-events { margin-top: 8px; }
+    .topic-events summary {
+        cursor: pointer;
+        font-size: 12px;
+        color: #2563eb;
+        padding: 4px 0;
+    }
+    .topic-events summary:hover { text-decoration: underline; }
+    .topic-events ul {
+        list-style: none;
+        margin: 6px 0;
+        padding: 0;
+        max-height: 240px;
+        overflow-y: auto;
+    }
+    .topic-events li {
+        font-size: 12px;
+        color: #475569;
+        padding: 6px 0;
+        border-top: 1px solid #f1f5f9;
+        display: flex;
+        gap: 8px;
+        align-items: flex-start;
+    }
+    .topic-events li .ev-date { color: #94a3b8; font-size: 11px; flex-shrink: 0; min-width: 70px; }
+    .topic-events li .ev-title a { color: #2563eb; text-decoration: none; }
+    .topic-events li .ev-title a:hover { text-decoration: underline; }
+    .topic-related-load {
+        margin-top: 10px;
+        font-size: 12px;
+        color: #2563eb;
+        cursor: pointer;
+        background: none;
+        border: none;
+        padding: 0;
+        text-decoration: underline;
+    }
+    .topic-related-out {
+        margin-top: 8px;
+        font-size: 12px;
+        color: #475569;
+        background: #f8fafc;
+        border-radius: 6px;
+        padding: 0;
+    }
+    .topic-related-out:not(:empty) { padding: 10px 12px; }
+    .topic-empty {
+        text-align: center;
+        padding: 40px 20px;
+        color: #94a3b8;
+        font-size: 13px;
+        background: #fff;
+        border-radius: 8px;
+    }
+</style>
+
+{% if topic_clusters %}
+<div class="topic-grid">
+    {% for tc in topic_clusters %}
+    <div class="topic-card">
+        <div class="topic-keywords">
+            {% for kw in tc.keywords %}
+            <span class="topic-kw">{{ kw }}</span>
+            {% endfor %}
+        </div>
+        <div class="topic-meta">
+            <span>이벤트 <b>{{ tc.event_count }}</b>건</span>
+            <span>청크 <b>{{ tc.chunk_count }}</b>개</span>
+            <span>{{ tc.first_seen.strftime('%m-%d') }} ~ {{ tc.last_seen.strftime('%m-%d') }}</span>
+        </div>
+        <div class="ins-sev-bar">
+            {% for sev, cnt in tc.severity_mix.items() %}
+            {% if cnt > 0 %}
+            <span class="ins-sev ins-sev-{{ sev }}">{{ sev }} {{ cnt }}</span>
+            {% endif %}
+            {% endfor %}
+        </div>
+        <details class="topic-events">
+            <summary>이벤트 {{ tc.event_count }}건 펼치기</summary>
+            <ul>
+                {% for e in tc.events %}
+                <li>
+                    <span class="ev-date">{{ e.occurred_at.strftime('%m-%d %H:%M') }}</span>
+                    <span class="ev-title">
+                        {% if e.source_url %}
+                        <a href="{{ e.source_url }}" target="_blank" rel="noopener">{{ e.title or '(제목 없음)' }}</a>
+                        {% else %}
+                        {{ e.title or '(제목 없음)' }}
+                        {% endif %}
+                        {% if e.service_tag %}<span style="color:#94a3b8;"> · {{ e.service_tag }}</span>{% endif %}
+                    </span>
+                </li>
+                {% endfor %}
+            </ul>
+        </details>
+        <button class="topic-related-load"
+                hx-get="{{ base_path }}/dashboard/insights/topics/{{ tc.cluster_key }}/related"
+                hx-target="next .topic-related-out"
+                hx-swap="innerHTML"
+                hx-disabled-elt="this">
+            관련 과거 뉴스레터 보기
+        </button>
+        <div class="topic-related-out"></div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<div class="topic-empty">
+    최근 {{ cluster_days }}일간 임계치({{ "0.35" }}) 이하로 묶이는 토픽 클러스터가 없습니다.
+    수집 청크가 적거나 임베딩 미생성 상태일 수 있습니다.
+</div>
+{% endif %}
 
 <!-- PR3 placeholder -->
 <div class="ins-future">

--- a/app/templates/dashboard/partials/topic_related.html
+++ b/app/templates/dashboard/partials/topic_related.html
@@ -1,0 +1,18 @@
+{% if related %}
+<ul style="list-style:none; margin:0; padding:0;">
+    {% for r in related %}
+    <li style="padding:6px 0; border-top:1px solid #e2e8f0;">
+        <div style="display:flex; justify-content:space-between; gap:8px; font-size:11px; color:#94a3b8;">
+            <span>
+                {% if r.headline %}<b style="color:#1e293b;">{{ r.headline }}</b>{% endif %}
+                {% if r.period_start %}<span style="margin-left:6px;">{{ r.period_start }} ~ {{ r.period_end }}</span>{% endif %}
+            </span>
+            <span>dist {{ "%.3f" | format(r.distance) }}</span>
+        </div>
+        <div style="margin-top:4px; color:#475569; font-size:12px;">{{ r.excerpt }}{% if r.excerpt | length >= 240 %}…{% endif %}</div>
+    </li>
+    {% endfor %}
+</ul>
+{% else %}
+<div style="color:#94a3b8; font-size:12px;">유사한 과거 뉴스레터 청크가 없습니다.</div>
+{% endif %}


### PR DESCRIPTION
## Summary
- pgvector cosine 거리 기반 단일-링크 union-find 클러스터링 서비스 신규 (`topic_cluster_service`)
- `/dashboard/insights` 에 섹션 ② "기술 토픽 클러스터" 추가
- 토픽 카드 → "관련 과거 뉴스레터 보기" 클릭 시 HTMX 로 corpus_newsletters 유사 청크 top-3 lazy load
- 외부 의존(numpy/sklearn) 추가 없음, 신규 마이그레이션 없음

## Base
- **이 PR 의 base 는 `feat/dashboard-insights-pr1` 입니다.** PR1 머지 후 main 으로 rebase 해주세요.

## 알고리즘
1. 최근 30일 `corpus_qa` / `corpus_logs` / `corpus_fixes` 청크 fetch (max 300)
2. SQL `embedding <=> embedding < 0.35` 로 인접 쌍 추출
3. Python union-find 로 클러스터 → min_size=3 미만 제거
4. 클러스터당: 이벤트 dedup → 키워드(한·영 토큰 빈도) / severity 분포 / first·last_seen / 이벤트 리스트
5. 관련 뉴스레터: 대표 chunk 임베딩 → `corpus_newsletters` cosine top-3

## 변경 파일
- `app/services/topic_cluster_service.py` — 신규 (~250 LOC)
- `app/api/v1/endpoints/dashboard.py` — `/dashboard/insights` 확장 + `/insights/topics/{key}/related` 파셜
- `app/templates/dashboard/insights.html` — 섹션 ② 추가
- `app/templates/dashboard/partials/topic_related.html` — 신규

## 튜닝 포인트
- `distance_threshold=0.35` / `min_cluster_size=3` / `cluster_days=30` — 데이터 양 보고 조정
- 청크가 적을 때(<3) 빈 상태 안내 노출
- 페이지 로드 시 클러스터링이 무거우면 별도 캐시 테이블 / 백그라운드 잡 분리 검토

## Test plan
- [ ] `/dashboard/insights` 접속 → 섹션 ② 노출 / 데이터 부족 시 안내 메시지
- [ ] 토픽 카드: 키워드 / 이벤트수 / severity bar / 기간 정상 노출
- [ ] "이벤트 N건 펼치기" → 이벤트 리스트, source_url 클릭 → 외부 링크 새 탭
- [ ] "관련 과거 뉴스레터 보기" → HTMX 로 유사 청크 3건 노출
- [ ] PR1 의 섹션 ① / 사이드바 / severity 필터 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)