### PR TITLE
feat(insights): HopenVision 적용 플랜 LLM 제안 (PR3/3)

### DIFF
--- a/alembic/versions/e5f6g7h8i9j0_add_hopenvision_proposals.py
+++ b/alembic/versions/e5f6g7h8i9j0_add_hopenvision_proposals.py
@@ -1,0 +1,57 @@
+"""add hopenvision_proposals table (PR3)
+
+Revision ID: e5f6g7h8i9j0
+Revises: d4e5f6g7h8i9
+Create Date: 2026-05-04 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "e5f6g7h8i9j0"
+down_revision: Union[str, None] = "d4e5f6g7h8i9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "hopenvision_proposals",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("cluster_key", sa.String(40), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.Column("model", sa.String(80), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False,
+                  server_default="generated"),
+        sa.Column("cluster_keywords",
+                  postgresql.ARRAY(sa.String()), nullable=False,
+                  server_default="{}"),
+        sa.Column("diagnosis", sa.Text(), nullable=True),
+        sa.Column("candidate_modules", postgresql.JSONB(astext_type=sa.Text()),
+                  nullable=False, server_default="[]"),
+        sa.Column("risks", postgresql.JSONB(astext_type=sa.Text()),
+                  nullable=False, server_default="[]"),
+        sa.Column("priority", sa.String(10), nullable=True),
+        sa.Column("raw_response", sa.Text(), nullable=True),
+        sa.Column("eval_ms", sa.Integer(), nullable=True),
+        sa.Column("dev_plan_id", sa.Integer(),
+                  sa.ForeignKey("dev_plans.id", ondelete="SET NULL"),
+                  nullable=True),
+    )
+    op.create_index("ix_hopenvision_proposals_cluster_key",
+                    "hopenvision_proposals", ["cluster_key"])
+    op.create_index("ix_hopenvision_proposals_dev_plan_id",
+                    "hopenvision_proposals", ["dev_plan_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_hopenvision_proposals_dev_plan_id",
+                  table_name="hopenvision_proposals")
+    op.drop_index("ix_hopenvision_proposals_cluster_key",
+                  table_name="hopenvision_proposals")
+    op.drop_table("hopenvision_proposals")

--- a/app/api/v1/endpoints/dashboard.py
+++ b/app/api/v1/endpoints/dashboard.py
@@ -271,15 +271,18 @@ def stats_page(
 @router.get("/dev-plans", response_class=HTMLResponse)
 def dev_plans_page(db: Session = Depends(get_db)):
     """개발 플랜 현황 페이지"""
+    from ....services.hopenvision_proposal_service import get_ai_generated_plan_ids
+
     service = get_dev_plan_service()
     overall = service.get_overall_metrics(db)
     projects = service.get_project_summary(db)
 
-    # 프로젝트별 플랜 목록 (상세 링크용)
-    from sqlalchemy.orm import joinedload
+    # 프로젝트별 플랜 목록 (상세 링크용) — AI 제안 DRAFT 도 노출
     all_plans = (
         db.query(DevPlan)
-        .filter(DevPlan.status.in_([PlanStatus.ACTIVE, PlanStatus.COMPLETED]))
+        .filter(DevPlan.status.in_(
+            [PlanStatus.DRAFT, PlanStatus.ACTIVE, PlanStatus.COMPLETED]
+        ))
         .order_by(DevPlan.project_name, DevPlan.updated_at.desc())
         .all()
     )
@@ -287,11 +290,14 @@ def dev_plans_page(db: Session = Depends(get_db)):
     for plan in all_plans:
         plans_by_project.setdefault(plan.project_name, []).append(plan)
 
+    ai_generated_plan_ids = get_ai_generated_plan_ids(db)
+
     return _render(
         "dev_plans.html",
         overall=overall,
         projects=projects,
         plans_by_project=plans_by_project,
+        ai_generated_plan_ids=ai_generated_plan_ids,
         active_page="dev_plans",
     )
 
@@ -511,3 +517,46 @@ def insights_topic_related(cluster_key: str, db: Session = Depends(get_db)):
     from ....services.topic_cluster_service import get_related_newsletters
     related = get_related_newsletters(db, cluster_key, top_k=3)
     return _render("partials/topic_related.html", related=related)
+
+
+@router.post("/insights/topics/{cluster_key}/hopenvision/generate",
+             response_class=HTMLResponse)
+def insights_hopenvision_generate(
+    cluster_key: str,
+    force: bool = Query(default=False),
+    db: Session = Depends(get_db),
+):
+    """HTMX: 토픽 클러스터 → HopenVision 적용 LLM 제안 생성/조회."""
+    from ....services.hopenvision_proposal_service import generate_proposal
+    try:
+        result = generate_proposal(db, cluster_key, force=force)
+    except ValueError as e:
+        return _render("partials/hopenvision_proposal.html",
+                       error=str(e), proposal=None)
+    except Exception as e:  # noqa: BLE001
+        import logging
+        logging.getLogger(__name__).exception("hopenvision generate 실패")
+        return _render("partials/hopenvision_proposal.html",
+                       error=f"제안 생성 중 오류: {e}", proposal=None)
+    return _render("partials/hopenvision_proposal.html",
+                   proposal=result, error=None)
+
+
+@router.post("/insights/proposals/{proposal_id}/accept",
+             response_class=HTMLResponse)
+def insights_hopenvision_accept(proposal_id: str, db: Session = Depends(get_db)):
+    """HTMX: 제안 수락 → DevPlan 자동 초안 생성."""
+    from ....services.hopenvision_proposal_service import accept_as_dev_plan
+    try:
+        plan = accept_as_dev_plan(db, proposal_id)
+    except ValueError as e:
+        html = f'<div style="color:#cf222e; font-size:12px;">{e}</div>'
+        return HTMLResponse(content=html, status_code=400)
+    href = f"{settings.root_path}/dashboard/dev-plans/{plan.id}"
+    html = (
+        f'<div style="color:#16a34a; font-size:12px; padding:8px 0;">'
+        f'✓ DevPlan 초안 생성됨 — '
+        f'<a href="{href}" style="color:#2563eb; text-decoration:underline;">'
+        f'#{plan.id} {plan.title}</a></div>'
+    )
+    return HTMLResponse(content=html)

--- a/app/models/insight.py
+++ b/app/models/insight.py
@@ -9,7 +9,8 @@ Insight Newsletter (v2) 모델
 import uuid
 
 from sqlalchemy import (
-    BigInteger, Column, Date, DateTime, ForeignKey, String, Text, UniqueConstraint, func,
+    BigInteger, Column, Date, DateTime, ForeignKey, Integer, String, Text,
+    UniqueConstraint, func,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import relationship
@@ -87,6 +88,33 @@ class NewsletterChunk(Base):
         embedding = Column(Vector(768), nullable=True)
 
     event = relationship("IngestionEvent", lazy="joined", foreign_keys=[event_id])
+
+
+class HopenVisionProposal(Base):
+    """토픽 클러스터 → HopenVision 적용 LLM 제안 (PR3).
+
+    DevPlan 자동 초안화 전 단계의 캐시. status 가 'accepted' 가 되면
+    dev_plan_id 가 채워진다.
+    """
+    __tablename__ = "hopenvision_proposals"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+                server_default=func.gen_random_uuid())
+    cluster_key = Column(String(40), nullable=False, index=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    model = Column(String(80), nullable=False)
+    status = Column(String(20), nullable=False, default="generated",
+                    server_default="generated")  # generated|accepted|failed
+    cluster_keywords = Column(ARRAY(String), nullable=False, default=list,
+                              server_default="{}")
+    diagnosis = Column(Text, nullable=True)
+    candidate_modules = Column(JSONB, nullable=False, default=list, server_default="[]")
+    risks = Column(JSONB, nullable=False, default=list, server_default="[]")
+    priority = Column(String(10), nullable=True)
+    raw_response = Column(Text, nullable=True)
+    eval_ms = Column(Integer, nullable=True)
+    dev_plan_id = Column(Integer, ForeignKey("dev_plans.id", ondelete="SET NULL"),
+                         nullable=True, index=True)
 
 
 # Collection 상수

--- a/app/services/hopenvision_proposal_service.py
+++ b/app/services/hopenvision_proposal_service.py
@@ -1,0 +1,307 @@
+"""
+HopenVision 적용 플랜 제안 서비스 (PR3).
+
+- 입력: topic_cluster_service 의 클러스터 + 최근 hopenvision WorkItem context
+- LLM(exaone3.5) 호출 → 구조화 JSON {diagnosis, candidate_modules, risks, priority}
+- 결과를 hopenvision_proposals 테이블에 캐시
+- 사용자 수락 시 DevPlan 자동 초안화
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..core.config import settings
+from ..models.dev_plan import (
+    DevPlan, DevPlanItem, PlanStatus, PlanItemStatus, PlanItemPriority,
+)
+from ..models.insight import HopenVisionProposal
+from ..models.issue import WorkItem
+from ..synthesis.ollama_client import chat
+from .topic_cluster_service import get_topic_clusters
+
+logger = logging.getLogger(__name__)
+
+HOPENVISION_REPO = "hopenvision"
+HOPENVISION_PROJECT = "hopenvision"
+
+_SYSTEM_PROMPT = """당신은 HopenVision 프로젝트의 시니어 엔지니어다. 외부에서 수집된
+기술 토픽을 보고 HopenVision 코드베이스에 적용 가능한 구체적 플랜을 작성한다.
+
+응답은 반드시 아래 JSON 스키마로만 답한다 — 다른 텍스트나 마크다운 코드블록 없이 순수 JSON.
+
+{
+  "diagnosis": "현재 HopenVision 의 관련 영역에 대한 진단 (3-5문장 한국어)",
+  "candidate_modules": [
+    {"module": "후보 모듈/디렉터리/파일명", "rationale": "왜 적용 가치가 있는지 (1-2문장)", "effort": "S|M|L"}
+  ],
+  "risks": ["예상 리스크 항목 (각 1문장)"],
+  "priority": "P0|P1|P2|P3"
+}
+
+규칙:
+- candidate_modules 는 2-5 개
+- risks 는 1-4 개
+- 모든 텍스트는 한국어로 작성
+- 추측이 과하지 않게, 토픽 키워드와 명확히 연결되는 것만 제안"""
+
+
+_JSON_BLOCK_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+@dataclass
+class ProposalResult:
+    proposal_id: str
+    cluster_key: str
+    diagnosis: Optional[str]
+    candidate_modules: list
+    risks: list
+    priority: Optional[str]
+    model: str
+    eval_ms: int
+    status: str  # generated|failed
+    raw_response: Optional[str]
+
+
+def _build_user_prompt(cluster_summary: dict, hopenvision_context: list[dict]) -> str:
+    parts = ["[수집된 기술 토픽]"]
+    parts.append(f"키워드: {', '.join(cluster_summary['keywords'])}")
+    parts.append(f"이벤트 수: {cluster_summary['event_count']}건 / "
+                 f"기간: {cluster_summary['first_seen']} ~ {cluster_summary['last_seen']}")
+    parts.append("최근 이벤트 샘플:")
+    for ev in cluster_summary["sample_events"][:8]:
+        parts.append(f"  - [{ev.get('severity', '?')}] {ev.get('title', '')} "
+                     f"(category={ev.get('category')}, service={ev.get('service_tag')})")
+
+    parts.append("")
+    parts.append("[HopenVision 최근 30일 활동 (DB workitem)]")
+    if hopenvision_context:
+        for w in hopenvision_context[:15]:
+            parts.append(f"  - [{w['status']}/{w['category']}] {w['title']}")
+    else:
+        parts.append("  (최근 활동 없음)")
+
+    parts.append("")
+    parts.append("위 토픽이 HopenVision 에 어떻게 적용될 수 있을지 JSON 으로 제안하라.")
+    return "\n".join(parts)
+
+
+def _summarize_cluster(cluster) -> dict:
+    return {
+        "keywords": cluster.keywords,
+        "event_count": cluster.event_count,
+        "first_seen": cluster.first_seen.strftime("%Y-%m-%d"),
+        "last_seen": cluster.last_seen.strftime("%Y-%m-%d"),
+        "sample_events": [
+            {
+                "title": e.title,
+                "severity": e.severity,
+                "category": e.category,
+                "service_tag": e.service_tag,
+            }
+            for e in cluster.events
+        ],
+    }
+
+
+def _fetch_hopenvision_context(session: Session, days: int = 30) -> list[dict]:
+    from sqlalchemy import text
+    rows = session.execute(text("""
+        SELECT title, category, status, updated_at
+        FROM work_items
+        WHERE github_repo = :repo
+          AND updated_at >= NOW() - make_interval(days => :days)
+        ORDER BY updated_at DESC
+        LIMIT 30
+    """), {"repo": HOPENVISION_REPO, "days": days}).mappings().all()
+    return [
+        {
+            "title": r["title"],
+            "category": str(r["category"].value) if hasattr(r["category"], "value") else str(r["category"]),
+            "status": str(r["status"].value) if hasattr(r["status"], "value") else str(r["status"]),
+        }
+        for r in rows
+    ]
+
+
+def _parse_llm_json(raw: str) -> Optional[dict]:
+    if not raw:
+        return None
+    # 마크다운 코드블록 제거
+    cleaned = raw.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```[a-zA-Z]*\n?", "", cleaned)
+        cleaned = re.sub(r"\n?```$", "", cleaned)
+    # 첫 번째 {...} 블록
+    m = _JSON_BLOCK_RE.search(cleaned)
+    if not m:
+        return None
+    try:
+        return json.loads(m.group(0))
+    except json.JSONDecodeError as e:
+        logger.warning("hopenvision: LLM JSON 파싱 실패 — %s", e)
+        return None
+
+
+def generate_proposal(
+    session: Session,
+    cluster_key: str,
+    *,
+    cluster_days: int = 30,
+    force: bool = False,
+) -> ProposalResult:
+    """클러스터 → HopenVision 제안 생성. 동일 cluster_key 의 최신 캐시가 있으면 재사용."""
+    if not force:
+        cached = session.scalars(
+            select(HopenVisionProposal)
+            .where(HopenVisionProposal.cluster_key == cluster_key,
+                   HopenVisionProposal.status == "generated")
+            .order_by(HopenVisionProposal.created_at.desc())
+            .limit(1)
+        ).first()
+        if cached:
+            return ProposalResult(
+                proposal_id=str(cached.id),
+                cluster_key=cluster_key,
+                diagnosis=cached.diagnosis,
+                candidate_modules=cached.candidate_modules or [],
+                risks=cached.risks or [],
+                priority=cached.priority,
+                model=cached.model,
+                eval_ms=cached.eval_ms or 0,
+                status=cached.status,
+                raw_response=cached.raw_response,
+            )
+
+    # 클러스터 재조회 — cluster_key 일치하는 것만 사용
+    clusters = get_topic_clusters(session, days=cluster_days)
+    target = next((c for c in clusters if c.cluster_key == cluster_key), None)
+    if target is None:
+        raise ValueError(f"cluster_key={cluster_key} 를 현재 클러스터링 결과에서 찾을 수 없습니다")
+
+    cluster_sum = _summarize_cluster(target)
+    hopenvision_ctx = _fetch_hopenvision_context(session)
+
+    user_prompt = _build_user_prompt(cluster_sum, hopenvision_ctx)
+    model = settings.ollama_model_compose
+
+    gen = chat(
+        model=model,
+        system=_SYSTEM_PROMPT,
+        user=user_prompt,
+        temperature=0.2,
+        max_tokens=1500,
+    )
+
+    parsed = _parse_llm_json(gen.text) if gen.ok else None
+
+    proposal = HopenVisionProposal(
+        cluster_key=cluster_key,
+        model=model,
+        status="generated" if (gen.ok and parsed) else "failed",
+        cluster_keywords=target.keywords,
+        diagnosis=(parsed or {}).get("diagnosis") if parsed else None,
+        candidate_modules=(parsed or {}).get("candidate_modules", []) if parsed else [],
+        risks=(parsed or {}).get("risks", []) if parsed else [],
+        priority=(parsed or {}).get("priority") if parsed else None,
+        raw_response=gen.text,
+        eval_ms=gen.eval_duration_ms,
+    )
+    session.add(proposal)
+    session.flush()
+    session.commit()
+
+    return ProposalResult(
+        proposal_id=str(proposal.id),
+        cluster_key=cluster_key,
+        diagnosis=proposal.diagnosis,
+        candidate_modules=proposal.candidate_modules,
+        risks=proposal.risks,
+        priority=proposal.priority,
+        model=model,
+        eval_ms=gen.eval_duration_ms,
+        status=proposal.status,
+        raw_response=gen.text,
+    )
+
+
+_PRIORITY_MAP = {
+    "P0": PlanItemPriority.P0,
+    "P1": PlanItemPriority.P1,
+    "P2": PlanItemPriority.P2,
+    "P3": PlanItemPriority.P3,
+}
+
+
+def accept_as_dev_plan(session: Session, proposal_id: str) -> DevPlan:
+    """제안 → DevPlan(DRAFT) + DevPlanItem 자동 초안화."""
+    p = session.get(HopenVisionProposal, proposal_id)
+    if p is None:
+        raise ValueError(f"proposal_id={proposal_id} not found")
+    if p.dev_plan_id is not None:
+        plan = session.get(DevPlan, p.dev_plan_id)
+        if plan:
+            return plan
+
+    keywords = ", ".join(p.cluster_keywords[:3]) if p.cluster_keywords else "외부 기술 토픽"
+    title = f"[AI 제안] {keywords} 적용 검토"
+
+    overall_priority = _PRIORITY_MAP.get(p.priority or "", PlanItemPriority.P2)
+    description = (p.diagnosis or "") + "\n\n[리스크]\n" + "\n".join(
+        f"- {r}" for r in (p.risks or [])
+    )
+
+    plan = DevPlan(
+        project_name=HOPENVISION_PROJECT,
+        github_repo="bluevlad/hopenvision",
+        title=title,
+        description=description.strip() or None,
+        status=PlanStatus.DRAFT,
+        total_phases=1,
+        current_phase=1,
+    )
+    session.add(plan)
+    session.flush()
+
+    for idx, mod in enumerate(p.candidate_modules or []):
+        if not isinstance(mod, dict):
+            continue
+        module_name = (mod.get("module") or "").strip()
+        rationale = (mod.get("rationale") or "").strip()
+        effort = (mod.get("effort") or "").upper()
+        if not module_name:
+            continue
+        item = DevPlanItem(
+            plan_id=plan.id,
+            phase=1,
+            phase_title="AI 제안 적용 검토",
+            sort_order=idx,
+            title=module_name[:500],
+            description=rationale or None,
+            priority=overall_priority,
+            status=PlanItemStatus.TODO,
+            weight={"S": 0.5, "M": 1.0, "L": 2.0}.get(effort, 1.0),
+        )
+        session.add(item)
+
+    p.dev_plan_id = plan.id
+    p.status = "accepted"
+    session.commit()
+    return plan
+
+
+def get_ai_generated_plan_ids(session: Session) -> set[int]:
+    """DevPlan 화면에서 'AI 제안' 라벨을 표시할 plan_id 목록."""
+    rows = session.execute(
+        select(HopenVisionProposal.dev_plan_id)
+        .where(HopenVisionProposal.dev_plan_id.is_not(None),
+               HopenVisionProposal.status == "accepted")
+    ).all()
+    return {r[0] for r in rows if r[0] is not None}

--- a/app/templates/dashboard/dev_plans.html
+++ b/app/templates/dashboard/dev_plans.html
@@ -238,6 +238,9 @@
             <a href="{{ base_path }}/dashboard/dev-plans/{{ plan.id }}"
                style="font-size:12px; color:#2563eb; text-decoration:none; margin-left:12px;">
                 {{ plan.title }}
+                {% if plan.id in ai_generated_plan_ids %}
+                <span class="plan-status-badge" style="background:#fef3c7; color:#92400e;">AI 제안</span>
+                {% endif %}
                 <span class="plan-status-badge plan-status-{{ plan.status.value }}">{{ plan.status.value }}</span>
                 &rarr;
             </a>

--- a/app/templates/dashboard/insights.html
+++ b/app/templates/dashboard/insights.html
@@ -319,14 +319,25 @@
                 {% endfor %}
             </ul>
         </details>
-        <button class="topic-related-load"
-                hx-get="{{ base_path }}/dashboard/insights/topics/{{ tc.cluster_key }}/related"
-                hx-target="next .topic-related-out"
-                hx-swap="innerHTML"
-                hx-disabled-elt="this">
-            관련 과거 뉴스레터 보기
-        </button>
+        <div style="display:flex; gap:14px; flex-wrap:wrap; margin-top:6px;">
+            <button class="topic-related-load"
+                    hx-get="{{ base_path }}/dashboard/insights/topics/{{ tc.cluster_key }}/related"
+                    hx-target="next .topic-related-out"
+                    hx-swap="innerHTML"
+                    hx-disabled-elt="this">
+                관련 과거 뉴스레터 보기
+            </button>
+            <button class="topic-related-load topic-hv-btn"
+                    hx-post="{{ base_path }}/dashboard/insights/topics/{{ tc.cluster_key }}/hopenvision/generate"
+                    hx-target="next .topic-hv-out"
+                    hx-swap="innerHTML"
+                    hx-indicator="next .topic-hv-out"
+                    hx-disabled-elt="this">
+                HopenVision 에 적용 (LLM)
+            </button>
+        </div>
         <div class="topic-related-out"></div>
+        <div class="topic-hv-out"></div>
     </div>
     {% endfor %}
 </div>
@@ -337,9 +348,14 @@
 </div>
 {% endif %}
 
-<!-- PR3 placeholder -->
-<div class="ins-future">
-    <strong>③ HopenVision 적용 플랜 분석</strong> — 토픽 → LLM 적용 제안 → DevPlan 자동 초안 · PR3 작업 예정
+<!-- Section ③: HopenVision Application Plan -->
+<div class="card-header" style="margin-top:32px; margin-bottom:12px;">
+    <h2 style="font-size:15px; color:#1e293b;">③ HopenVision 적용 플랜 (AI 제안)</h2>
+    <span style="font-size:12px; color:#94a3b8;">토픽 카드의 "HopenVision 에 적용" 버튼으로 LLM 분석</span>
+</div>
+<div style="background:#fff; border-radius:8px; padding:14px 18px; box-shadow:0 1px 3px rgba(0,0,0,0.06); font-size:13px; color:#475569; line-height:1.7;">
+    각 토픽 카드의 <code style="background:#f6f8fa; padding:1px 5px; border-radius:3px;">HopenVision 에 적용 (LLM)</code> 버튼을 누르면 exaone3.5 가 토픽 + 최근 hopenvision WorkItem 을 보고 적용 후보 모듈/리스크/우선순위 JSON 을 작성합니다.
+    이후 "DevPlan 으로 만들기"를 누르면 <a href="{{ base_path }}/dashboard/dev-plans" style="color:#2563eb;">Dev Plans</a> 화면에 <span style="background:#fef3c7; color:#92400e; padding:1px 6px; border-radius:8px; font-size:11px; font-weight:600;">AI 제안</span> 라벨이 붙은 DRAFT 플랜으로 자동 초안화됩니다.
 </div>
 
 <!-- Preview modal -->

--- a/app/templates/dashboard/partials/hopenvision_proposal.html
+++ b/app/templates/dashboard/partials/hopenvision_proposal.html
@@ -1,0 +1,73 @@
+{% if error %}
+<div style="margin-top:8px; padding:10px 12px; background:#ffebe9; color:#cf222e;
+            border-radius:6px; font-size:12px;">
+    ⚠ {{ error }}
+</div>
+{% elif proposal %}
+<div style="margin-top:10px; background:#f8fafc; border:1px solid #e2e8f0;
+            border-radius:8px; padding:12px 14px;">
+    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
+        <span style="font-size:11px; color:#94a3b8;">
+            model={{ proposal.model }} · {{ proposal.eval_ms }}ms
+            {% if proposal.priority %}· <b style="color:#1e293b;">{{ proposal.priority }}</b>{% endif %}
+        </span>
+        {% if proposal.status == 'failed' %}
+        <span style="font-size:11px; color:#cf222e;">JSON 파싱 실패 — raw 확인 필요</span>
+        {% endif %}
+    </div>
+
+    {% if proposal.diagnosis %}
+    <div style="margin-bottom:10px;">
+        <div style="font-size:11px; font-weight:600; color:#64748b; margin-bottom:4px;">진단</div>
+        <div style="font-size:12px; color:#334155; line-height:1.6;">{{ proposal.diagnosis }}</div>
+    </div>
+    {% endif %}
+
+    {% if proposal.candidate_modules %}
+    <div style="margin-bottom:10px;">
+        <div style="font-size:11px; font-weight:600; color:#64748b; margin-bottom:4px;">적용 후보 모듈</div>
+        <ul style="margin:0; padding-left:18px; font-size:12px;">
+            {% for m in proposal.candidate_modules %}
+            <li style="margin-bottom:4px;">
+                <b style="color:#1e293b;">{{ m.module }}</b>
+                {% if m.effort %}<span style="background:#e0e7ff; color:#3730a3; padding:1px 6px; border-radius:8px; font-size:10px; margin-left:4px;">{{ m.effort }}</span>{% endif %}
+                {% if m.rationale %}<div style="color:#475569; margin-top:2px;">{{ m.rationale }}</div>{% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
+    {% if proposal.risks %}
+    <div style="margin-bottom:10px;">
+        <div style="font-size:11px; font-weight:600; color:#64748b; margin-bottom:4px;">예상 리스크</div>
+        <ul style="margin:0; padding-left:18px; font-size:12px; color:#475569;">
+            {% for r in proposal.risks %}
+            <li>{{ r }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
+    {% if proposal.status == 'generated' and proposal.candidate_modules %}
+    <button class="topic-related-load"
+            hx-post="{{ base_path }}/dashboard/insights/proposals/{{ proposal.proposal_id }}/accept"
+            hx-target="next .hv-accept-out"
+            hx-swap="innerHTML"
+            hx-disabled-elt="this"
+            style="margin-top:6px;">
+        DevPlan 으로 만들기
+    </button>
+    <div class="hv-accept-out"></div>
+    {% endif %}
+
+    {% if proposal.status == 'failed' and proposal.raw_response %}
+    <details style="margin-top:8px;">
+        <summary style="font-size:11px; color:#94a3b8; cursor:pointer;">raw response (debug)</summary>
+        <pre style="font-size:11px; background:#f6f8fa; padding:8px; border-radius:4px; max-height:240px; overflow:auto; white-space:pre-wrap;">{{ proposal.raw_response }}</pre>
+    </details>
+    {% endif %}
+</div>
+{% else %}
+<div style="font-size:12px; color:#94a3b8; padding:8px 0;">제안 데이터가 없습니다.</div>
+{% endif %}


### PR DESCRIPTION
## Summary
- 토픽 클러스터(PR2) → HopenVision 적용 LLM 제안 → DevPlan 자동 초안화 파이프라인 추가
- exaone3.5(`OLLAMA_MODEL_COMPOSE`) 호출 → 구조화 JSON 파싱 → 캐시 (`hopenvision_proposals`)
- 사용자 수락 시 DevPlan(DRAFT) + DevPlanItem 자동 생성, Dev Plans 화면에 **AI 제안** 라벨 노출

## Base
- 이 PR 의 base 는 `feat/dashboard-insights-pr2` 입니다. PR1 → PR2 머지 후 main 으로 rebase.

## 마이그레이션
- `alembic/versions/e5f6g7h8i9j0_add_hopenvision_proposals.py`
  - 신규 테이블 `hopenvision_proposals` (UUID PK, cluster_key idx, dev_plan_id FK→dev_plans)
- `alembic upgrade head` 필요

## 새 엔드포인트
- `POST /dashboard/insights/topics/{cluster_key}/hopenvision/generate` — HTMX, 캐시 우선
- `POST /dashboard/insights/proposals/{proposal_id}/accept` — DevPlan 변환

## 변경 파일
- `app/models/insight.py` — `HopenVisionProposal` 모델 추가
- `alembic/versions/e5f6g7h8i9j0_*.py` — 신규
- `app/services/hopenvision_proposal_service.py` — 신규 (~310 LOC)
- `app/api/v1/endpoints/dashboard.py` — 라우트 2 개 + dev-plans 라우트 확장(DRAFT 노출 + AI 제안 ID 전달)
- `app/templates/dashboard/insights.html` — 토픽 카드에 LLM 버튼 추가, 섹션 ③ 안내
- `app/templates/dashboard/partials/hopenvision_proposal.html` — 신규
- `app/templates/dashboard/dev_plans.html` — `ai_generated_plan_ids` 라벨링

## LLM 설계
- **system prompt**: HopenVision 시니어 엔지니어 페르소나 + JSON 스키마 강제
- **user prompt**: 클러스터 키워드/기간/이벤트샘플 + 최근 30일 hopenvision WorkItem
- **파싱**: 마크다운 코드블록 제거 + 첫 `{…}` 블록 `json.loads`. 실패 시 status=failed + raw 노출
- **재호출**: 동일 cluster_key 의 generated 캐시가 있으면 재사용 (force=true 옵션)

## 한계 / 후속
- exaone3.5 가 JSON 스키마 어기는 빈도가 잦으면 `format=json` 옵션 또는 retry 로직 검토
- DevPlan 초안에 phase 분리는 현재 단일 phase. 후속에서 effort=L 만 phase 2 로 분리 등 정교화 가능
- AI 제안 라벨은 dev_plans 페이지의 플랜 링크에만 표시 — 상세 페이지/projects 페이지 노출은 후속

## Test plan
- [ ] `alembic upgrade head` — `hopenvision_proposals` 생성 확인
- [ ] 토픽 카드의 "HopenVision 에 적용" 버튼 클릭 → 진단/후보 모듈/리스크 렌더
- [ ] LLM 가용 (Ollama 호스트 도달) — 첫 호출 시 비동기 응답 ~수십 초 소요
- [ ] 캐시 동작: 같은 카드 재클릭 → 같은 결과 즉시 반환
- [ ] LLM 응답이 JSON 이 아닐 때 status=failed + raw 노출 확인
- [ ] "DevPlan 으로 만들기" → /dashboard/dev-plans 에서 DRAFT + "AI 제안" 라벨 확인
- [ ] 생성된 DevPlan 상세 페이지에서 candidate_modules → DevPlanItem 매핑 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)