### PR TITLE
feat(tech-trend): TechTrend connector 인프라 추가 (PR1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,18 @@ GITHUB_QA_LABEL=qa-agent
 AUTO_TOBE_ENABLED=false
 AUTO_TOBE_JOURNAL_GLOB=
 AUTO_TOBE_GIT_REPOS=
+
+# Tech Trend (Medium Daily Digest 리포트 + Google/Naver 뉴스 검색)
+# medium-digest-agent 가 생성한 Markdown 리포트(reports/) 를 흡수하고
+# 키워드별로 Google News RSS / Naver News API 로 보강 → 주간 뉴스레터의
+# "이번 주 기술 토픽" 섹션 + HopenVision 적용 제안에 사용.
+TECH_TREND_ENABLED=false
+TECH_TREND_KEYWORDS=java,spring,react
+MEDIUM_DIGEST_REPORTS_DIR=
+TECH_NEWS_MAX_PER_KEYWORD=5
+TECH_NEWS_WORKERS=4
+TECH_NEWS_TIMEOUT_SEC=15
+
+# Naver News API (선택 — 미설정 시 Google News RSS 만 사용)
+NAVER_CLIENT_ID=
+NAVER_CLIENT_SECRET=

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -93,6 +93,22 @@ class Settings(BaseSettings):
     auto_tobe_journal_glob: str = Field(default="", env="AUTO_TOBE_JOURNAL_GLOB")  # 예: /work/*/AUTO_TOBE_*.md
     auto_tobe_git_repos: str = Field(default="", env="AUTO_TOBE_GIT_REPOS")  # ":" 구분 로컬 경로
 
+    # Tech Trend (Medium Daily Digest 리포트 + Google/Naver 뉴스 검색)
+    tech_trend_enabled: bool = Field(default=False, env="TECH_TREND_ENABLED")
+    tech_trend_keywords: str = Field(
+        default="java,spring,react", env="TECH_TREND_KEYWORDS",
+    )  # 콤마 구분 — 뉴스 검색 키워드, 디지스트 결과 키워드 필터에도 사용
+    medium_digest_reports_dir: str = Field(
+        default="", env="MEDIUM_DIGEST_REPORTS_DIR",
+    )  # 예: /Users/rainend/GIT/medium-digest-agent/reports
+    tech_news_max_per_keyword: int = Field(default=5, env="TECH_NEWS_MAX_PER_KEYWORD")
+    tech_news_workers: int = Field(default=4, env="TECH_NEWS_WORKERS")
+    tech_news_timeout_sec: int = Field(default=15, env="TECH_NEWS_TIMEOUT_SEC")
+
+    # Naver News API (선택 — 미설정 시 Google News RSS 만 사용)
+    naver_client_id: str = Field(default="", env="NAVER_CLIENT_ID")
+    naver_client_secret: str = Field(default="", env="NAVER_CLIENT_SECRET")
+
     # 합성 윈도우
     insight_window_days: int = Field(default=7, env="INSIGHT_WINDOW_DAYS")
     insight_subject_prefix: str = Field(default="[StandUp Insight]", env="INSIGHT_SUBJECT_PREFIX")
@@ -115,6 +131,10 @@ class Settings(BaseSettings):
     @property
     def auto_tobe_git_repo_list(self) -> list[str]:
         return [r.strip() for r in self.auto_tobe_git_repos.split(":") if r.strip()]
+
+    @property
+    def tech_trend_keyword_list(self) -> list[str]:
+        return [k.strip() for k in self.tech_trend_keywords.split(",") if k.strip()]
 
     @property
     def is_insight_mode(self) -> bool:

--- a/app/ingestion/connectors/__init__.py
+++ b/app/ingestion/connectors/__init__.py
@@ -9,9 +9,11 @@ from ..base import Connector
 from .loganalyzer import LogAnalyzerConnector
 from .github_qa import GitHubQAConnector
 from .auto_tobe import AutoTobeConnector
+from .tech_trend import TechTrendConnector
 
 __all__ = [
     "LogAnalyzerConnector", "GitHubQAConnector", "AutoTobeConnector",
+    "TechTrendConnector",
     "build_connectors",
 ]
 
@@ -38,6 +40,12 @@ def build_connectors() -> list[Connector]:
         connectors.append(AutoTobeConnector(
             journal_glob=settings.auto_tobe_journal_glob,
             git_repos=settings.auto_tobe_git_repo_list,
+        ))
+
+    if settings.tech_trend_enabled:
+        connectors.append(TechTrendConnector(
+            keywords=settings.tech_trend_keyword_list,
+            reports_dir=settings.medium_digest_reports_dir,
         ))
 
     return connectors

--- a/app/ingestion/connectors/tech_trend.py
+++ b/app/ingestion/connectors/tech_trend.py
@@ -1,0 +1,236 @@
+"""Tech Trend connector — 기술 동향 통합 수집.
+
+두 채널을 섞어 `corpus_tech` 코퍼스를 만든다:
+
+1. **Medium Daily Digest 리포트** (`medium-digest-agent` 가 생성한 Markdown)
+   — 메일 수집 자체는 medium-digest-agent 가 담당하고, StandUp 은 그 산출물만 흡수.
+2. **Google News RSS / Naver News API** 키워드 검색
+   — `TECH_TREND_KEYWORDS` 단위로 최근 동향 보강. Medium Digest 가 비어 있어도
+   동작하도록 별도 채널로 운영.
+
+`source_type` 두 종을 사용:
+- `medium_digest_report` — 디지스트에서 흡수한 LLM 분석 리포트 1건
+- `tech_news_article` — 외부 뉴스 기사 1건
+
+두 종 모두 `corpus_tech` 컬렉션으로 색인되어 합성 단계의 RAG 검색에 사용된다.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from ...core.config import settings
+from ...models.insight import (
+    COLLECTION_TECH,
+    SOURCE_MEDIUM_DIGEST_REPORT,
+    SOURCE_TECH_NEWS_ARTICLE,
+)
+from ...services.medium_digest_reader import (
+    DigestReport,
+    MediumDigestReaderService,
+)
+from ...services.tech_news_search import (
+    KeywordSearchResult,
+    NewsArticle,
+    TechNewsSearchService,
+)
+from ..base import Connector
+from ..schemas import CanonicalEvent, ChunkSpec, FetchResult
+
+logger = logging.getLogger(__name__)
+
+# 검색 결과의 발행일이 윈도우 양 끝에서 며칠 어긋나도 흡수.
+_BUFFER = timedelta(days=2)
+
+
+class TechTrendConnector(Connector):
+    name = "tech_trend"
+
+    def __init__(
+        self,
+        keywords: list[str],
+        reports_dir: str = "",
+        digest_reader: Optional[MediumDigestReaderService] = None,
+        news_service: Optional[TechNewsSearchService] = None,
+    ):
+        self.keywords = [k for k in keywords if k]
+        self.reports_dir = reports_dir
+        self.digest_reader = digest_reader or MediumDigestReaderService(
+            reports_dir=reports_dir, keywords=self.keywords,
+        )
+        self.news_service = news_service or TechNewsSearchService()
+
+    def fetch(self, since: datetime, until: datetime) -> FetchResult:
+        started = datetime.now(timezone.utc)
+        events: list[CanonicalEvent] = []
+
+        # 1. Medium Digest 리포트 흡수
+        try:
+            digest_reports = self.digest_reader.list_reports(since, until)
+        except Exception as e:  # noqa: BLE001 — 외부 의존성 장애 흡수
+            logger.warning("tech_trend digest 읽기 실패: %s", e)
+            digest_reports = []
+
+        for report in digest_reports:
+            events.append(self._digest_to_event(report))
+
+        # 2. 키워드별 뉴스 검색 (키워드 비어있으면 skip)
+        if self.keywords:
+            try:
+                news_results = self.news_service.search_many(self.keywords)
+            except Exception as e:  # noqa: BLE001
+                logger.warning("tech_trend news 검색 실패: %s", e)
+                news_results = {}
+            for keyword, kwres in news_results.items():
+                events.extend(self._news_to_events(keyword, kwres, since, until))
+
+        logger.info(
+            "tech_trend: digest=%d, news=%d (keywords=%s)",
+            len(digest_reports),
+            sum(1 for e in events if e.source_type == SOURCE_TECH_NEWS_ARTICLE),
+            ",".join(self.keywords),
+        )
+
+        return FetchResult(
+            events=events, connector_name=self.name,
+            started_at=started, finished_at=datetime.now(timezone.utc),
+        )
+
+    # ── Digest 리포트 변환 ────────────────────────────────────────────────
+    def _digest_to_event(self, report: DigestReport) -> CanonicalEvent:
+        # corpus_tech 청크 — RAG 가 충분히 활용할 수 있도록 핵심 섹션을 텍스트화
+        body_lines: list[str] = [f"[Digest] {report.title}"]
+        if report.keyword:
+            body_lines.append(f"키워드: {report.keyword}")
+        if report.category:
+            body_lines.append(f"카테고리: {report.category}")
+        if report.priority:
+            body_lines.append(f"우선순위: {report.priority}")
+        if report.tech_description:
+            body_lines.append("\n## 기술 설명\n" + report.tech_description)
+        if report.target_scope:
+            body_lines.append("\n## 적용 대상\n" + report.target_scope)
+        if report.changes:
+            body_lines.append("\n## 변경 사항\n" + report.changes)
+        if report.risks:
+            body_lines.append("\n## 리스크\n" + report.risks)
+        chunk_text = "\n".join(body_lines)
+
+        canonical = {
+            "title": report.title,
+            "keyword": report.keyword,
+            "category": report.category,
+            "priority": report.priority,
+            "difficulty": report.difficulty,
+            "maturity": report.maturity,
+            "source_newsletter": report.source_newsletter,
+            "references": report.references,
+            "tech_description": report.tech_description,
+            "current_state": report.current_state,
+            "target_scope": report.target_scope,
+            "changes": report.changes,
+            "expected_effects": report.expected_effects,
+            "risks": report.risks,
+            "pilot_scope": report.pilot_scope,
+            "file_path": str(report.file_path),
+        }
+
+        return CanonicalEvent(
+            source_type=SOURCE_MEDIUM_DIGEST_REPORT,
+            source_id=report.source_id,
+            occurred_at=report.occurred_at,
+            title=report.title,
+            source_url=f"file://{report.file_path}",
+            service_tag=None,
+            severity=self._severity_from_priority(report.priority),
+            category=report.category or "tech_proposal",
+            canonical=canonical,
+            raw_excerpt=report.short_excerpt,
+            extra_chunks=[
+                ChunkSpec(
+                    text=chunk_text,
+                    collection=COLLECTION_TECH,
+                    metadata={
+                        "source": "medium_digest_report",
+                        "keyword": report.keyword,
+                        "category": report.category,
+                        "priority": report.priority,
+                        "slug": report.slug,
+                    },
+                ),
+            ],
+        )
+
+    # ── News article 변환 ─────────────────────────────────────────────────
+    def _news_to_events(
+        self,
+        keyword: str,
+        result: KeywordSearchResult,
+        since: datetime,
+        until: datetime,
+    ) -> list[CanonicalEvent]:
+        out: list[CanonicalEvent] = []
+        for article in result.articles:
+            occurred_at = article.published_at or datetime.now(timezone.utc)
+            # tz-naive 인 경우 UTC 로 보정
+            if occurred_at.tzinfo is None:
+                occurred_at = occurred_at.replace(tzinfo=timezone.utc)
+            # 윈도우 외 기사는 스킵 (검색이 더 넓게 잡았을 수 있음)
+            if occurred_at < since - _BUFFER or occurred_at > until + _BUFFER:
+                continue
+
+            url = article.url or ""
+            url_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16] if url else ""
+            source_id = f"{article.source}:{keyword}:{url_hash}" if url_hash \
+                else f"{article.source}:{keyword}:{article.fingerprint}"
+
+            chunk_text = (
+                f"[Tech News:{article.source}] {article.title}\n"
+                f"키워드: {keyword}\n"
+                f"{article.description}"
+            )
+
+            out.append(CanonicalEvent(
+                source_type=SOURCE_TECH_NEWS_ARTICLE,
+                source_id=source_id,
+                occurred_at=occurred_at,
+                title=article.title,
+                source_url=url or None,
+                service_tag=None,
+                severity="info",
+                category="tech_news",
+                canonical={
+                    "keyword": keyword,
+                    "source": article.source,  # google|naver
+                    "description": article.description,
+                    "published_at": occurred_at.isoformat(),
+                },
+                raw_excerpt=article.description[:240],
+                extra_chunks=[
+                    ChunkSpec(
+                        text=chunk_text,
+                        collection=COLLECTION_TECH,
+                        metadata={
+                            "source": "tech_news_article",
+                            "news_source": article.source,
+                            "keyword": keyword,
+                        },
+                    ),
+                ],
+            ))
+        return out
+
+    @staticmethod
+    def _severity_from_priority(priority: str) -> str | None:
+        if not priority:
+            return None
+        p = priority.strip().lower()
+        if p in ("critical", "high", "medium", "low"):
+            return p
+        # 한글 표기 매핑
+        return {
+            "긴급": "critical", "높음": "high", "중간": "medium", "낮음": "low",
+        }.get(p)

--- a/app/ingestion/schemas.py
+++ b/app/ingestion/schemas.py
@@ -49,7 +49,7 @@ class ChunkSpec:
     """RAG 색인용 청크 사양 — connector 가 권장하는 분할."""
 
     text: str
-    collection: str            # corpus_qa|corpus_logs|corpus_fixes
+    collection: str            # corpus_qa|corpus_logs|corpus_fixes|corpus_tech
     metadata: dict[str, Any] = field(default_factory=dict)
 
 

--- a/app/models/insight.py
+++ b/app/models/insight.py
@@ -122,9 +122,12 @@ COLLECTION_QA = "corpus_qa"
 COLLECTION_LOGS = "corpus_logs"
 COLLECTION_FIXES = "corpus_fixes"
 COLLECTION_NEWSLETTERS = "corpus_newsletters"
+COLLECTION_TECH = "corpus_tech"
 
 # Source type 상수
 SOURCE_LOGANALYZER = "loganalyzer"
 SOURCE_GITHUB_QA = "github_qa"
 SOURCE_AUTO_TOBE_JOURNAL = "auto_tobe_journal"
 SOURCE_AUTO_TOBE_COMMIT = "auto_tobe_commit"
+SOURCE_MEDIUM_DIGEST_REPORT = "medium_digest_report"
+SOURCE_TECH_NEWS_ARTICLE = "tech_news_article"

--- a/app/services/medium_digest_reader.py
+++ b/app/services/medium_digest_reader.py
@@ -1,0 +1,286 @@
+"""medium-digest-agent 가 생성한 Markdown 리포트 리더.
+
+리포트 디렉토리(예: /Users/rainend/GIT/medium-digest-agent/reports/) 에서
+파일명이 `YYYY-MM-DD-{slug}.md` 인 리포트를 파싱해 구조화 dict 로 반환한다.
+StandUp 자체적으로 메일을 다시 가져오지 않고 medium-digest-agent 의 산출물만
+흡수해 뉴스레터 합성/HopenVision 제안 입력으로 활용한다.
+
+리포트 헤더 섹션 예 (한글 고정):
+
+    # [Java 21+] 적용 제안 — academy-admin/backend
+
+    ## 요약
+    - **기술 키워드**: Java 21+
+    - **카테고리**: language-features
+    - **출처 뉴스레터**: ...
+    - **분석일**: 2026-04-13
+    - **우선순위**: medium
+    - **도입 난이도**: medium
+    - **기술 성숙도**: mainstream
+
+    ## 참고 자료
+    - [Title - Source](https://...)
+    - [Title - Source](https://...)
+
+    ## 기술 설명
+    Java 21은 ...
+
+    ## 현재 서비스 현황
+    ...
+
+    ## 적용 대상
+    | 모듈 영역 | ... |
+
+    ## 변경 사항
+    ...
+
+    ## 예상 효과
+    ...
+
+    ## 리스크 및 롤백 전략
+    ...
+
+이 모듈은 medium-digest-agent 의 출력 포맷이 위 구조를 유지한다는 가정을 따른다.
+포맷이 바뀌면 `_SECTION_ALIASES` 만 보강하면 된다.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_FILENAME_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})-(.+)\.md$")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_BULLET_KV_RE = re.compile(r"^[-*]\s*\*\*(?P<key>[^:*]+)\*\*\s*[:：]\s*(?P<value>.+)$")
+_HEADING_RE = re.compile(r"^(#{1,6})\s*(.+?)\s*$")
+
+# 섹션 별칭 — 한글 표기 흔들림 흡수용
+_SECTION_ALIASES = {
+    "요약": "summary",
+    "참고 자료": "references",
+    "참고자료": "references",
+    "기술 설명": "tech_description",
+    "기술설명": "tech_description",
+    "현재 서비스 현황": "current_state",
+    "적용 대상": "target_scope",
+    "변경 사항": "changes",
+    "예상 효과": "expected_effects",
+    "리스크 및 롤백 전략": "risks",
+    "리스크": "risks",
+    "파일럿 적용 범위": "pilot_scope",
+    "승인": "approval",
+}
+
+# 메타데이터 키 별칭
+_META_KEY_ALIASES = {
+    "기술 키워드": "keyword",
+    "카테고리": "category",
+    "출처 뉴스레터": "source_newsletter",
+    "분석일": "analyzed_date",
+    "우선순위": "priority",
+    "도입 난이도": "difficulty",
+    "기술 성숙도": "maturity",
+}
+
+
+@dataclass
+class DigestReport:
+    """파싱된 medium-digest-agent 리포트."""
+
+    file_path: Path
+    file_date: date
+    slug: str
+    title: str                                  # H1
+    keyword: str = ""                           # 요약 메타: 기술 키워드
+    category: str = ""
+    source_newsletter: str = ""
+    priority: str = ""
+    difficulty: str = ""
+    maturity: str = ""
+    references: list[dict[str, str]] = field(default_factory=list)  # [{title,url}]
+    tech_description: str = ""
+    current_state: str = ""
+    target_scope: str = ""
+    changes: str = ""
+    expected_effects: str = ""
+    risks: str = ""
+    pilot_scope: str = ""
+    raw_text: str = ""
+
+    @property
+    def occurred_at(self) -> datetime:
+        """뉴스레터 timeline 용 KST 자정 timestamp."""
+        return datetime.combine(self.file_date, time(0, 0), tzinfo=timezone.utc)
+
+    @property
+    def source_id(self) -> str:
+        return f"{self.file_date.isoformat()}-{self.slug}"
+
+    @property
+    def short_excerpt(self) -> str:
+        body = self.tech_description or self.current_state or self.expected_effects
+        body = body.replace("\n", " ").strip()
+        return (body[:240] + "…") if len(body) > 240 else body
+
+
+def _parse_summary_bullets(lines: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in lines:
+        m = _BULLET_KV_RE.match(line.strip())
+        if not m:
+            continue
+        key = m.group("key").strip()
+        value = m.group("value").strip()
+        canonical = _META_KEY_ALIASES.get(key)
+        if canonical:
+            out[canonical] = value
+    return out
+
+
+def _parse_reference_links(lines: list[str]) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    for line in lines:
+        for title, url in _LINK_RE.findall(line):
+            out.append({"title": title.strip(), "url": url.strip()})
+    return out
+
+
+def _split_sections(text: str) -> tuple[str, dict[str, list[str]]]:
+    """H1 제목 + (H2 섹션명 → 라인 리스트) 매핑으로 분해."""
+    title = ""
+    sections: dict[str, list[str]] = {}
+    current: Optional[str] = None
+    buffer: list[str] = []
+
+    def flush():
+        nonlocal buffer
+        if current is not None:
+            sections.setdefault(current, []).extend(buffer)
+        buffer = []
+
+    for raw_line in text.splitlines():
+        m = _HEADING_RE.match(raw_line)
+        if m:
+            level = len(m.group(1))
+            heading = m.group(2).strip()
+            if level == 1 and not title:
+                title = heading
+                continue
+            if level == 2:
+                flush()
+                canonical = _SECTION_ALIASES.get(heading.strip())
+                current = canonical or heading.strip()
+                continue
+        if current is not None:
+            buffer.append(raw_line)
+    flush()
+    return title, sections
+
+
+def _join(lines: list[str]) -> str:
+    # leading/trailing 공백 라인 제거 후 join
+    while lines and not lines[0].strip():
+        lines = lines[1:]
+    while lines and not lines[-1].strip():
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def parse_report(file_path: Path) -> Optional[DigestReport]:
+    """단일 markdown 리포트 파싱. 실패 시 None."""
+    name = file_path.name
+    fname_match = _FILENAME_RE.match(name)
+    if not fname_match:
+        return None
+    file_date = date.fromisoformat(fname_match.group(1))
+    slug = fname_match.group(2)
+
+    try:
+        text = file_path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning("digest 리포트 읽기 실패 %s: %s", file_path, e)
+        return None
+
+    title, sections = _split_sections(text)
+    summary_meta = _parse_summary_bullets(sections.get("summary", []))
+    refs = _parse_reference_links(sections.get("references", []))
+
+    return DigestReport(
+        file_path=file_path,
+        file_date=file_date,
+        slug=slug,
+        title=title or slug,
+        keyword=summary_meta.get("keyword", ""),
+        category=summary_meta.get("category", ""),
+        source_newsletter=summary_meta.get("source_newsletter", ""),
+        priority=summary_meta.get("priority", ""),
+        difficulty=summary_meta.get("difficulty", ""),
+        maturity=summary_meta.get("maturity", ""),
+        references=refs,
+        tech_description=_join(sections.get("tech_description", [])),
+        current_state=_join(sections.get("current_state", [])),
+        target_scope=_join(sections.get("target_scope", [])),
+        changes=_join(sections.get("changes", [])),
+        expected_effects=_join(sections.get("expected_effects", [])),
+        risks=_join(sections.get("risks", [])),
+        pilot_scope=_join(sections.get("pilot_scope", [])),
+        raw_text=text,
+    )
+
+
+def _matches_keyword_filter(report: DigestReport, allow: set[str]) -> bool:
+    """allow 가 비어있으면 모두 통과. 아니면 keyword/category/title 부분 매칭."""
+    if not allow:
+        return True
+    haystack = " ".join([
+        report.keyword, report.category, report.title, report.slug,
+    ]).lower()
+    return any(token in haystack for token in allow)
+
+
+class MediumDigestReaderService:
+    """리포트 디렉토리를 [since, until] 윈도우로 스캔."""
+
+    def __init__(self, reports_dir: str, keywords: Optional[list[str]] = None):
+        self.reports_dir = Path(reports_dir) if reports_dir else None
+        self._keyword_filter = {k.strip().lower() for k in (keywords or []) if k.strip()}
+
+    def is_available(self) -> bool:
+        return self.reports_dir is not None and self.reports_dir.is_dir()
+
+    def list_reports(
+        self,
+        since: datetime,
+        until: datetime,
+    ) -> list[DigestReport]:
+        if not self.is_available():
+            return []
+        assert self.reports_dir is not None  # is_available 가 True 일 때만
+
+        since_d = since.date()
+        until_d = until.date()
+        out: list[DigestReport] = []
+        for path in sorted(self.reports_dir.glob("*.md")):
+            m = _FILENAME_RE.match(path.name)
+            if not m:
+                continue
+            try:
+                file_date = date.fromisoformat(m.group(1))
+            except ValueError:
+                continue
+            if file_date < since_d or file_date > until_d:
+                continue
+            report = parse_report(path)
+            if report is None:
+                continue
+            if not _matches_keyword_filter(report, self._keyword_filter):
+                continue
+            out.append(report)
+        return out

--- a/app/services/tech_news_search.py
+++ b/app/services/tech_news_search.py
@@ -1,0 +1,269 @@
+"""기술 동향 뉴스 검색 서비스.
+
+키워드 단위로 외부 뉴스 소스를 동시에 호출해 NewsArticle 리스트를 반환한다.
+AllergyInsight 의 google_news_service / naver_news_service 패턴을 차용해
+- Google News RSS (별도 키 불필요)
+- Naver News API (Client ID/Secret 가 있을 때만)
+두 소스의 결과를 sha256(title+url) 로 중복 제거 후 병합한다.
+
+본 모듈은 자체 영속성을 갖지 않으며, 상위 connector 가 결과를
+`CanonicalEvent` 로 변환해 IngestionHub 에 넘긴다.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime
+from email.utils import parsedate_to_datetime
+from typing import Optional
+from urllib.parse import quote
+
+import feedparser
+import requests
+
+from ..core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NewsArticle:
+    title: str
+    url: str
+    source: str            # "google" | "naver"
+    description: str
+    published_at: Optional[datetime]
+    search_keyword: str
+
+    @property
+    def fingerprint(self) -> str:
+        """중복 판단용 해시 — title+url 기준."""
+        key = f"{self.title.strip().lower()}|{self.url.strip().lower()}"
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+
+
+@dataclass
+class KeywordSearchResult:
+    keyword: str
+    articles: list[NewsArticle] = field(default_factory=list)
+    elapsed_ms: float = 0.0
+    sources: list[str] = field(default_factory=list)
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_HTML_ENTITIES = (
+    ("&quot;", '"'), ("&amp;", "&"), ("&lt;", "<"),
+    ("&gt;", ">"), ("&apos;", "'"), ("&#39;", "'"),
+)
+
+
+def _strip_html(text: str) -> str:
+    if not text:
+        return ""
+    clean = _HTML_TAG_RE.sub("", text)
+    for entity, replacement in _HTML_ENTITIES:
+        clean = clean.replace(entity, replacement)
+    return clean.strip()
+
+
+def _parse_rss_date(date_str: str) -> Optional[datetime]:
+    if not date_str:
+        return None
+    try:
+        return parsedate_to_datetime(date_str)
+    except (TypeError, ValueError):
+        return None
+
+
+class GoogleNewsRSS:
+    """Google News RSS 검색 (키 불필요)."""
+
+    BASE_URL = "https://news.google.com/rss/search"
+
+    def search(
+        self,
+        query: str,
+        *,
+        lang: str = "ko",
+        country: str = "KR",
+        when: str = "7d",
+        max_results: int = 10,
+        timeout: int = 15,
+    ) -> list[NewsArticle]:
+        search_query = f"{query} when:{when}" if when else query
+        url = (
+            f"{self.BASE_URL}?q={quote(search_query)}"
+            f"&hl={lang}&gl={country}&ceid={country}:{lang}"
+        )
+
+        try:
+            # feedparser 는 자체 fetch 도 가능하나 timeout 제어가 까다로워
+            # requests 로 받아 string 을 파싱한다.
+            resp = requests.get(
+                url,
+                timeout=timeout,
+                headers={"User-Agent": "StandUp-TechTrend/1.0"},
+            )
+            resp.raise_for_status()
+            feed = feedparser.parse(resp.text)
+        except Exception as e:  # noqa: BLE001 — 외부 장애 흡수
+            logger.warning("google news RSS 실패 (q=%s): %s", query, e)
+            return []
+
+        out: list[NewsArticle] = []
+        for entry in feed.entries[:max_results]:
+            description = _strip_html(
+                entry.get("summary", "") or entry.get("description", "")
+            )[:500]
+            out.append(NewsArticle(
+                title=entry.get("title", ""),
+                url=entry.get("link", ""),
+                source="google",
+                description=description,
+                published_at=_parse_rss_date(entry.get("published", "")),
+                search_keyword=query,
+            ))
+        return out
+
+
+class NaverNewsAPI:
+    """Naver News 검색 API — Client ID/Secret 필요."""
+
+    BASE_URL = "https://openapi.naver.com/v1/search/news.json"
+
+    def __init__(self, client_id: str, client_secret: str):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._session = requests.Session()
+        self._session.headers.update({
+            "X-Naver-Client-Id": client_id,
+            "X-Naver-Client-Secret": client_secret,
+            "User-Agent": "StandUp-TechTrend/1.0",
+        })
+
+    def search(
+        self,
+        query: str,
+        *,
+        display: int = 10,
+        sort: str = "date",
+        timeout: int = 10,
+    ) -> list[NewsArticle]:
+        if not self.client_id or not self.client_secret:
+            return []
+        try:
+            resp = self._session.get(
+                self.BASE_URL,
+                params={
+                    "query": query,
+                    "display": min(display, 100),
+                    "sort": sort,
+                },
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("naver news API 실패 (q=%s): %s", query, e)
+            return []
+
+        out: list[NewsArticle] = []
+        for item in data.get("items", []):
+            out.append(NewsArticle(
+                title=_strip_html(item.get("title", "")),
+                url=item.get("link", ""),
+                source="naver",
+                description=_strip_html(item.get("description", "")),
+                published_at=_parse_rss_date(item.get("pubDate", "")),
+                search_keyword=query,
+            ))
+        return out
+
+
+class TechNewsSearchService:
+    """키워드 리스트 → 병렬 검색 → 중복 제거 결과."""
+
+    def __init__(
+        self,
+        *,
+        max_per_keyword: int | None = None,
+        workers: int | None = None,
+        timeout: int | None = None,
+        naver_client_id: str | None = None,
+        naver_client_secret: str | None = None,
+    ):
+        self.max_per_keyword = max_per_keyword or settings.tech_news_max_per_keyword
+        self.workers = workers or settings.tech_news_workers
+        self.timeout = timeout or settings.tech_news_timeout_sec
+        self.google = GoogleNewsRSS()
+        self.naver = NaverNewsAPI(
+            client_id=(naver_client_id if naver_client_id is not None
+                       else settings.naver_client_id),
+            client_secret=(naver_client_secret if naver_client_secret is not None
+                           else settings.naver_client_secret),
+        )
+
+    def search_one(self, keyword: str) -> KeywordSearchResult:
+        started = time.time()
+        sources: list[str] = []
+        articles: list[NewsArticle] = []
+        seen: set[str] = set()
+
+        google_articles = self.google.search(
+            keyword,
+            max_results=self.max_per_keyword,
+            timeout=self.timeout,
+        )
+        if google_articles:
+            sources.append("google")
+        for a in google_articles:
+            fp = a.fingerprint
+            if fp in seen:
+                continue
+            seen.add(fp)
+            articles.append(a)
+
+        naver_articles = self.naver.search(
+            keyword,
+            display=self.max_per_keyword,
+            timeout=self.timeout,
+        )
+        if naver_articles:
+            sources.append("naver")
+        for a in naver_articles:
+            fp = a.fingerprint
+            if fp in seen:
+                continue
+            seen.add(fp)
+            articles.append(a)
+
+        return KeywordSearchResult(
+            keyword=keyword,
+            articles=articles,
+            elapsed_ms=(time.time() - started) * 1000,
+            sources=sources,
+        )
+
+    def search_many(self, keywords: list[str]) -> dict[str, KeywordSearchResult]:
+        """키워드 리스트 병렬 검색 → 키워드별 결과 매핑."""
+        if not keywords:
+            return {}
+
+        results: dict[str, KeywordSearchResult] = {}
+        # ThreadPoolExecutor 의 워커 수는 keywords 수보다 클 필요 없음
+        max_workers = max(1, min(self.workers, len(keywords)))
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futures = {ex.submit(self.search_one, kw): kw for kw in keywords}
+            for fut in as_completed(futures):
+                kw = futures[fut]
+                try:
+                    results[kw] = fut.result(timeout=self.timeout * 2)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning("tech news search 키워드=%s 실패: %s", kw, e)
+                    results[kw] = KeywordSearchResult(keyword=kw)
+        return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,6 @@ python-dateutil>=2.8.2
 
 # Insight Newsletter (v2) — pgvector RAG (Ollama 는 host 호출이라 SDK 불필요)
 pgvector>=0.3.6
+
+# Tech Trend connector — Google News RSS / Naver News API 파싱
+feedparser>=6.0.11

--- a/tests/test_tech_trend.py
+++ b/tests/test_tech_trend.py
@@ -1,0 +1,302 @@
+"""TechTrend connector 단위 테스트.
+
+- medium-digest-agent 가 만드는 markdown 리포트 파싱 (실제 샘플 사용)
+- TechNewsSearchService 의 키워드 병렬 검색 (네트워크 모킹)
+- TechTrendConnector 가 두 채널을 합쳐 CanonicalEvent 로 정규화하는 로직
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.ingestion.connectors.tech_trend import TechTrendConnector
+from app.models.insight import (
+    COLLECTION_TECH,
+    SOURCE_MEDIUM_DIGEST_REPORT,
+    SOURCE_TECH_NEWS_ARTICLE,
+)
+from app.services.medium_digest_reader import (
+    MediumDigestReaderService,
+    parse_report,
+)
+from app.services.tech_news_search import (
+    KeywordSearchResult,
+    NewsArticle,
+    TechNewsSearchService,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "digest_reports"
+
+
+# ── fixture 생성 ──────────────────────────────────────────────────────────
+SAMPLE_MD = """\
+# [Java 21+] 적용 제안 — academy-admin/backend
+
+## 요약
+- **기술 키워드**: Java 21+
+- **카테고리**: language-features
+- **출처 뉴스레터**: Java 25 Features That Will Change the Way You Code Forever
+- **분석일**: 2026-04-13
+- **우선순위**: medium
+- **도입 난이도**: medium
+- **기술 성숙도**: mainstream
+
+## 참고 자료
+- [Oracle Releases Java 26 - Oracle](https://news.google.com/foo)
+- [How to enable Java 21 preview features - TheServerSide](https://news.google.com/bar)
+
+## 기술 설명
+
+Java 21은 패턴 매칭, sealed 클래스, 레코드 등의 기능을 도입했습니다.
+
+## 현재 서비스 현황
+
+- Spring Boot 3.2.0, Java 21
+- MySQL
+
+## 적용 대상
+
+| 모듈 영역 | 대상 파일 유형 | 변경 내용 |
+|---|---|---|
+| 새로운 개발 모듈 | *Api.java | 패턴 매칭 활용 |
+
+## 변경 사항
+
+```java
+switch (day) {
+    case MONDAY -> System.out.println("Start");
+}
+```
+
+## 예상 효과
+- 가독성 향상
+
+## 리스크 및 롤백 전략
+- 호환성 이슈 가능성
+
+## 파일럿 적용 범위
+새 모듈에서 먼저 검증
+
+## 승인
+- [ ] 관리자 승인
+"""
+
+
+@pytest.fixture(scope="module")
+def sample_report_dir(tmp_path_factory):
+    d = tmp_path_factory.mktemp("digest_reports")
+    (d / "2026-04-13-java-21.md").write_text(SAMPLE_MD, encoding="utf-8")
+    # 다른 날짜 파일 — keyword filter 테스트용
+    other = SAMPLE_MD.replace("Java 21+", "React 19").replace(
+        "language-features", "frontend",
+    ).replace("2026-04-13", "2026-04-14")
+    (d / "2026-04-14-react-19.md").write_text(other, encoding="utf-8")
+    # 윈도우 밖 (오래된 것)
+    (d / "2025-01-01-old.md").write_text(SAMPLE_MD, encoding="utf-8")
+    # 파일명 형식 안 맞는 것
+    (d / "README.md").write_text("# not a digest", encoding="utf-8")
+    return d
+
+
+# ── parse_report ────────────────────────────────────────────────────────
+def test_parse_report_extracts_metadata(sample_report_dir):
+    report = parse_report(sample_report_dir / "2026-04-13-java-21.md")
+    assert report is not None
+    assert report.title.startswith("[Java 21+]")
+    assert report.keyword == "Java 21+"
+    assert report.category == "language-features"
+    assert report.priority == "medium"
+    assert report.difficulty == "medium"
+    assert report.maturity == "mainstream"
+    assert report.file_date.isoformat() == "2026-04-13"
+    assert report.slug == "java-21"
+
+
+def test_parse_report_extracts_references(sample_report_dir):
+    report = parse_report(sample_report_dir / "2026-04-13-java-21.md")
+    assert report is not None
+    urls = [r["url"] for r in report.references]
+    assert "https://news.google.com/foo" in urls
+    assert "https://news.google.com/bar" in urls
+
+
+def test_parse_report_extracts_sections(sample_report_dir):
+    report = parse_report(sample_report_dir / "2026-04-13-java-21.md")
+    assert report is not None
+    assert "패턴 매칭" in report.tech_description
+    assert "Spring Boot" in report.current_state
+    assert "*Api.java" in report.target_scope
+    assert "case MONDAY" in report.changes
+    assert "가독성" in report.expected_effects
+    assert "호환성" in report.risks
+    assert "새 모듈" in report.pilot_scope
+
+
+def test_parse_report_returns_none_for_invalid_filename(tmp_path):
+    bad = tmp_path / "no-date.md"
+    bad.write_text("# x", encoding="utf-8")
+    assert parse_report(bad) is None
+
+
+# ── MediumDigestReaderService ───────────────────────────────────────────
+def test_reader_window_filters_by_date(sample_report_dir):
+    svc = MediumDigestReaderService(reports_dir=str(sample_report_dir))
+    since = datetime(2026, 4, 13, tzinfo=timezone.utc)
+    until = datetime(2026, 4, 14, tzinfo=timezone.utc)
+    reports = svc.list_reports(since, until)
+    slugs = {r.slug for r in reports}
+    assert slugs == {"java-21", "react-19"}
+
+
+def test_reader_keyword_filter_matches_substring(sample_report_dir):
+    svc = MediumDigestReaderService(
+        reports_dir=str(sample_report_dir), keywords=["java"],
+    )
+    since = datetime(2026, 4, 13, tzinfo=timezone.utc)
+    until = datetime(2026, 4, 14, tzinfo=timezone.utc)
+    reports = svc.list_reports(since, until)
+    assert {r.slug for r in reports} == {"java-21"}
+
+
+def test_reader_unavailable_when_dir_missing():
+    svc = MediumDigestReaderService(reports_dir="/nonexistent/path/zzz")
+    assert not svc.is_available()
+    assert svc.list_reports(
+        datetime(2026, 4, 13, tzinfo=timezone.utc),
+        datetime(2026, 4, 14, tzinfo=timezone.utc),
+    ) == []
+
+
+# ── TechNewsSearchService ────────────────────────────────────────────────
+def test_news_service_dedupes_across_sources():
+    svc = TechNewsSearchService(
+        max_per_keyword=5, workers=2, timeout=5,
+        naver_client_id="", naver_client_secret="",  # naver 비활성
+    )
+    duplicate_url = "https://news.example.com/post/1"
+    duplicate_title = "Java 26 released"
+
+    google_articles = [
+        NewsArticle(
+            title=duplicate_title, url=duplicate_url, source="google",
+            description="d1", published_at=None, search_keyword="java",
+        ),
+        NewsArticle(
+            title="Other Java news", url="https://news.example.com/post/2",
+            source="google", description="d2", published_at=None,
+            search_keyword="java",
+        ),
+    ]
+    naver_articles = [
+        NewsArticle(
+            title=duplicate_title, url=duplicate_url, source="naver",
+            description="d1-naver", published_at=None, search_keyword="java",
+        ),
+    ]
+
+    with patch.object(svc.google, "search", return_value=google_articles), \
+         patch.object(svc.naver, "search", return_value=naver_articles):
+        result = svc.search_one("java")
+
+    urls = [a.url for a in result.articles]
+    assert urls.count(duplicate_url) == 1, "중복 URL 이 한 번만 포함되어야 함"
+    assert "https://news.example.com/post/2" in urls
+
+
+def test_news_service_search_many_returns_keyword_map():
+    svc = TechNewsSearchService(
+        max_per_keyword=5, workers=2, timeout=5,
+        naver_client_id="", naver_client_secret="",
+    )
+
+    def fake_one(keyword: str) -> KeywordSearchResult:
+        return KeywordSearchResult(
+            keyword=keyword,
+            articles=[NewsArticle(
+                title=f"{keyword} title", url=f"https://x.com/{keyword}",
+                source="google", description="d", published_at=None,
+                search_keyword=keyword,
+            )],
+        )
+
+    with patch.object(svc, "search_one", side_effect=fake_one):
+        result = svc.search_many(["java", "react"])
+    assert set(result.keys()) == {"java", "react"}
+    assert result["java"].articles[0].title == "java title"
+
+
+# ── TechTrendConnector 통합 ────────────────────────────────────────────
+def test_connector_builds_canonical_events(sample_report_dir):
+    # 가짜 NewsService — 외부 호출 없이 KeywordSearchResult 반환
+    class FakeNewsService:
+        def search_many(self, keywords):
+            return {
+                kw: KeywordSearchResult(
+                    keyword=kw,
+                    articles=[NewsArticle(
+                        title=f"{kw} weekly news",
+                        url=f"https://news.example.com/{kw}",
+                        source="google",
+                        description=f"about {kw}",
+                        published_at=datetime(2026, 4, 13, 12, tzinfo=timezone.utc),
+                        search_keyword=kw,
+                    )],
+                )
+                for kw in keywords
+            }
+
+    digest_reader = MediumDigestReaderService(
+        reports_dir=str(sample_report_dir),
+        keywords=["java", "react"],
+    )
+    connector = TechTrendConnector(
+        keywords=["java", "react"],
+        reports_dir=str(sample_report_dir),
+        digest_reader=digest_reader,
+        news_service=FakeNewsService(),
+    )
+
+    since = datetime(2026, 4, 12, tzinfo=timezone.utc)
+    until = datetime(2026, 4, 14, 23, 59, tzinfo=timezone.utc)
+    res = connector.fetch(since, until)
+
+    assert res.error is None
+    sources = [e.source_type for e in res.events]
+    # digest 2건(java/react) + 뉴스 2건(java/react) = 4건
+    assert sources.count(SOURCE_MEDIUM_DIGEST_REPORT) == 2
+    assert sources.count(SOURCE_TECH_NEWS_ARTICLE) == 2
+
+    # corpus_tech 컬렉션으로만 chunk 가 만들어지는지
+    for ev in res.events:
+        assert ev.extra_chunks, f"{ev.source_type} 청크 누락"
+        for ch in ev.extra_chunks:
+            assert ch.collection == COLLECTION_TECH
+
+
+def test_connector_handles_empty_reports_dir():
+    connector = TechTrendConnector(
+        keywords=[],
+        reports_dir="",
+        digest_reader=MediumDigestReaderService(reports_dir=""),
+        news_service=TechNewsSearchService(
+            max_per_keyword=1, workers=1, timeout=1,
+            naver_client_id="", naver_client_secret="",
+        ),
+    )
+    res = connector.fetch(
+        datetime(2026, 4, 12, tzinfo=timezone.utc),
+        datetime(2026, 4, 14, tzinfo=timezone.utc),
+    )
+    assert res.error is None
+    assert res.events == []
+
+
+def test_connector_severity_from_priority():
+    assert TechTrendConnector._severity_from_priority("high") == "high"
+    assert TechTrendConnector._severity_from_priority("높음") == "high"
+    assert TechTrendConnector._severity_from_priority("") is None
+    assert TechTrendConnector._severity_from_priority("Unknown") is None


### PR DESCRIPTION
## Summary
- Medium Daily Digest 리포트(`medium-digest-agent` 산출물) + Google News RSS / Naver News API 검색을 통합하는 새 connector `TechTrendConnector` 추가
- AllergyInsight 의 `feedparser` + `requests` + `ThreadPoolExecutor` 패턴을 차용 (별도 유료 검색 API 키 불필요)
- 두 source(`medium_digest_report`, `tech_news_article`) 모두 `corpus_tech` 코퍼스로 색인 → 후속 PR2 합성 단계와 PR3 HopenVision 어댑터에서 활용

## 변경 내역
- `app/services/medium_digest_reader.py` — `YYYY-MM-DD-{slug}.md` 리포트 디렉토리 스캔, 한글 H2 섹션 파서, 키워드 필터
- `app/services/tech_news_search.py` — `GoogleNewsRSS` / `NaverNewsAPI` + `TechNewsSearchService` (sha256 중복 제거, 키워드별 병렬 검색)
- `app/ingestion/connectors/tech_trend.py` — `Connector` 상속, digest+news → `CanonicalEvent` + `ChunkSpec(corpus_tech)`
- `app/models/insight.py` — `COLLECTION_TECH`, `SOURCE_MEDIUM_DIGEST_REPORT`, `SOURCE_TECH_NEWS_ARTICLE` 상수
- `app/core/config.py` + `.env.example` — `TECH_TREND_*` / `MEDIUM_DIGEST_REPORTS_DIR` / `NAVER_CLIENT_*`
- `requirements.txt` — `feedparser>=6.0.11`
- `tests/test_tech_trend.py` — 12개 단위 테스트 (파서/검색/connector 통합)

## 의도된 비범위
- 합성 파이프라인(Stage2/3)에 tech_trend 분기 추가는 PR2 에서 진행
- HopenVision `propose_from_tech_topics()` 어댑터 + DevPlan 자동 초안화는 PR3 에서 진행

## Test plan
- [x] `python -m pytest tests/test_tech_trend.py -v` → 12 passed
- [x] `python -c "from app.ingestion.connectors import build_connectors; print(len(build_connectors()))"` → import 정상
- [ ] (운영 환경) `TECH_TREND_ENABLED=true`, `MEDIUM_DIGEST_REPORTS_DIR=/Users/rainend/GIT/medium-digest-agent/reports` 설정 후 `POST /api/v1/insight/ingest/run` 호출 시 `tech_trend` 가 per_connector 결과에 포함되는지
- [ ] `NAVER_CLIENT_ID/SECRET` 미설정 상태에서도 Google News RSS 만으로 동작하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)