### PR TITLE
feat(tech-trend): 합성 파이프라인 + 뉴스레터 '기술 토픽' 섹션 (PR2)

### DIFF
--- a/app/newsletter/builder.py
+++ b/app/newsletter/builder.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from ..core.config import now_kst, settings
-from ..synthesis.pipeline import SynthesisOutput
+from ..synthesis.pipeline import SynthesisOutput, TechTopic
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +131,31 @@ def _replace_refs(html_body: str) -> str:
     return REF_PATTERN.sub(repl, html_body)
 
 
+def _build_tech_topic_items(topics: list[TechTopic]) -> list[dict]:
+    """TechTopic → 템플릿이 바로 쓸 수 있는 dict 리스트로 변환.
+
+    digest_url 이 file:// 스킴이면 안전상 외부 링크로 노출하지 않고 텍스트만 표시.
+    """
+    out: list[dict] = []
+    for t in topics:
+        digest_url = t.digest_url
+        digest_url_safe = digest_url if digest_url.startswith(("http://", "https://")) else ""
+        out.append({
+            "keyword": t.keyword,
+            "digest_title": t.digest_title,
+            "digest_priority": (t.digest_priority or "").lower(),
+            "digest_category": t.digest_category,
+            "digest_difficulty": t.digest_difficulty,
+            "digest_maturity": t.digest_maturity,
+            "digest_summary": t.digest_summary,
+            "digest_target_scope": t.digest_target_scope,
+            "digest_risks": t.digest_risks,
+            "digest_url": digest_url_safe,
+            "news_articles": t.news_articles,
+        })
+    return out
+
+
 def _build_kpi_items(kpis: dict) -> list[dict]:
     items: list[dict] = []
     s = kpis.get("loganalyzer_summary") or {}
@@ -171,6 +196,7 @@ def render_newsletter(syn: SynthesisOutput) -> dict:
         period_end=syn.period_end.isoformat(),
         generated_at=now_kst().strftime("%Y-%m-%d %H:%M KST"),
         kpi_items=_build_kpi_items(syn.kpis),
+        tech_topics=_build_tech_topic_items(syn.tech_topics),
         body_html=body_html,
         feedback_up=feedback_up,
         feedback_down=feedback_down,

--- a/app/synthesis/pipeline.py
+++ b/app/synthesis/pipeline.py
@@ -20,7 +20,8 @@ from ..core.config import settings
 from ..core.database import SessionLocal
 from ..models.insight import (
     COLLECTION_FIXES, COLLECTION_LOGS, COLLECTION_NEWSLETTERS, COLLECTION_QA,
-    IngestionEvent, SOURCE_LOGANALYZER,
+    COLLECTION_TECH, IngestionEvent, SOURCE_LOGANALYZER,
+    SOURCE_MEDIUM_DIGEST_REPORT, SOURCE_TECH_NEWS_ARTICLE,
 )
 from ..rag.retriever import retrieve, RetrievedChunk
 from .ollama_client import chat
@@ -34,6 +35,24 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
+class TechTopic:
+    """tech_trend 이벤트 그룹 — 키워드 단위로 디지스트 1건 + 관련 뉴스 N건."""
+
+    keyword: str
+    digest_title: str = ""
+    digest_priority: str = ""
+    digest_category: str = ""
+    digest_difficulty: str = ""
+    digest_maturity: str = ""
+    digest_summary: str = ""
+    digest_target_scope: str = ""
+    digest_risks: str = ""
+    digest_url: str = ""
+    digest_event_id: str = ""
+    news_articles: list[dict] = field(default_factory=list)
+
+
+@dataclass
 class SynthesisOutput:
     period_start: date
     period_end: date
@@ -44,6 +63,7 @@ class SynthesisOutput:
     summaries: list[str]
     source_event_ids: list[str]
     rag_refs: list[dict]
+    tech_topics: list[TechTopic] = field(default_factory=list)
     meta: dict = field(default_factory=dict)
 
 
@@ -191,11 +211,90 @@ def _stage2_analyze(summaries: list[str], kpis: dict) -> dict:
 
 
 def _retrieve_rag_context(session: Session, query: str) -> list[RetrievedChunk]:
-    """과거 뉴스레터 + fix 사례 검색."""
+    """과거 뉴스레터 + fix 사례 + 기술 토픽 코퍼스 검색."""
     refs: list[RetrievedChunk] = []
     refs.extend(retrieve(session, query, COLLECTION_NEWSLETTERS, top_k=3))
     refs.extend(retrieve(session, query, COLLECTION_FIXES, top_k=3))
+    refs.extend(retrieve(session, query, COLLECTION_TECH, top_k=3))
     return refs
+
+
+def _collect_tech_topics(events: list[IngestionEvent]) -> list[TechTopic]:
+    """tech_trend 이벤트(digest + news)를 키워드 단위로 그룹핑.
+
+    각 키워드(소문자 정규화)에 대해:
+    - 가장 최근 medium_digest_report 1건을 대표 디지스트로 선택
+    - 같은 키워드의 tech_news_article 들을 news_articles 로 매핑
+    """
+    digest_by_kw: dict[str, IngestionEvent] = {}
+    news_by_kw: dict[str, list[IngestionEvent]] = {}
+    display_by_kw: dict[str, str] = {}  # 정규화 키 → 화면 표시용 원문 케이스
+
+    for ev in events:
+        kw = (ev.canonical or {}).get("keyword") or ""
+        kw_norm = kw.strip().lower()
+        if not kw_norm:
+            continue
+        # 디지스트가 있으면 그쪽 케이스를 우선 사용. 없으면 처음 본 뉴스의 케이스.
+        if kw_norm not in display_by_kw or ev.source_type == SOURCE_MEDIUM_DIGEST_REPORT:
+            display_by_kw[kw_norm] = kw.strip()
+        if ev.source_type == SOURCE_MEDIUM_DIGEST_REPORT:
+            existing = digest_by_kw.get(kw_norm)
+            if existing is None or ev.occurred_at > existing.occurred_at:
+                digest_by_kw[kw_norm] = ev
+        elif ev.source_type == SOURCE_TECH_NEWS_ARTICLE:
+            news_by_kw.setdefault(kw_norm, []).append(ev)
+
+    if not digest_by_kw and not news_by_kw:
+        return []
+
+    # 키워드 union — 디지스트 우선 정렬, 다음으로 뉴스만 있는 키워드
+    all_kws = list(digest_by_kw.keys()) + [
+        k for k in news_by_kw.keys() if k not in digest_by_kw
+    ]
+    topics: list[TechTopic] = []
+    for kw in all_kws:
+        digest_ev = digest_by_kw.get(kw)
+        news_evs = news_by_kw.get(kw, [])
+        # 뉴스는 최신순 정렬, 키워드당 최대 5건만 노출
+        news_evs.sort(key=lambda e: e.occurred_at, reverse=True)
+        news_evs = news_evs[:5]
+
+        topic = TechTopic(keyword=display_by_kw.get(kw, kw))
+        if digest_ev is not None:
+            c = digest_ev.canonical or {}
+            topic.digest_title = digest_ev.title or ""
+            topic.digest_priority = c.get("priority", "")
+            topic.digest_category = c.get("category", "")
+            topic.digest_difficulty = c.get("difficulty", "")
+            topic.digest_maturity = c.get("maturity", "")
+            topic.digest_summary = (c.get("tech_description") or "")[:600]
+            topic.digest_target_scope = (c.get("target_scope") or "")[:600]
+            topic.digest_risks = (c.get("risks") or "")[:600]
+            topic.digest_url = digest_ev.source_url or ""
+            topic.digest_event_id = str(digest_ev.id)
+        for nev in news_evs:
+            nc = nev.canonical or {}
+            topic.news_articles.append({
+                "title": nev.title,
+                "url": nev.source_url or "",
+                "source": nc.get("source", ""),
+                "description": (nc.get("description") or "")[:240],
+                "published_at": (
+                    nev.occurred_at.isoformat()
+                    if nev.occurred_at else ""
+                ),
+            })
+        topics.append(topic)
+
+    # 우선순위 high/critical 을 먼저, 그 다음 디지스트 있는 것, 그 다음 뉴스 수
+    _PRIORITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "": 9}
+    topics.sort(key=lambda t: (
+        _PRIORITY_ORDER.get((t.digest_priority or "").lower(), 9),
+        0 if t.digest_title else 1,
+        -len(t.news_articles),
+    ))
+    return topics
 
 
 def _format_rag_block(refs: list[RetrievedChunk]) -> str:
@@ -347,6 +446,9 @@ def synthesize(
         )
         meta["stage3_ms"] = int((datetime.now() - t0).total_seconds() * 1000)
 
+        tech_topics = _collect_tech_topics(events)
+        meta["tech_topic_count"] = len(tech_topics)
+
         return SynthesisOutput(
             period_start=period_start,
             period_end=period_end,
@@ -364,6 +466,7 @@ def synthesize(
                 }
                 for r in rag_refs
             ],
+            tech_topics=tech_topics,
             meta=meta,
         )
     finally:

--- a/app/templates/insight_newsletter.html
+++ b/app/templates/insight_newsletter.html
@@ -34,6 +34,21 @@
   .badge-high     { background: #fff8c5; color: #9a6700; }
   .badge-medium   { background: #ddf4ff; color: #0969da; }
   .badge-low      { background: #dafbe1; color: #1a7f37; }
+  .tech-section { margin-top: 28px; padding-top: 16px;
+                  border-top: 1px solid #e1e4e8; }
+  .tech-section > h2 { color: #ef4444; font-size: 18px; margin-bottom: 12px; }
+  .tech-topic { border: 1px solid #e1e4e8; border-radius: 6px; padding: 12px 16px;
+                margin-bottom: 12px; background: #fff; }
+  .tech-topic h3 { margin: 0; font-size: 15px; color: #1f2328; }
+  .tech-topic .kw { color: #ef4444; font-weight: 600; }
+  .tech-topic .meta-row { color: #57606a; font-size: 12px; margin: 4px 0 8px; }
+  .tech-topic .summary { font-size: 13px; color: #24292f; margin: 6px 0; }
+  .tech-topic .scope, .tech-topic .risk { font-size: 12px; color: #57606a;
+                                          margin-top: 4px; }
+  .tech-topic .label { font-weight: 600; color: #57606a; }
+  .tech-topic ul.news { padding-left: 18px; margin: 6px 0 0; }
+  .tech-topic ul.news li { font-size: 12.5px; color: #24292f; margin: 2px 0; }
+  .tech-topic .src-tag { color: #6e7781; font-size: 11px; margin-left: 4px; }
 </style>
 </head>
 <body>
@@ -50,6 +65,47 @@
   {% endif %}
 
   {{ body_html | safe }}
+
+  {% if tech_topics %}
+  <div class="tech-section">
+    <h2>이번 주 기술 토픽</h2>
+    {% for t in tech_topics %}
+    <div class="tech-topic">
+      <h3>
+        <span class="kw">{{ t.keyword }}</span>
+        {% if t.digest_title %}— {{ t.digest_title }}{% endif %}
+        {% if t.digest_priority %}<span class="badge badge-{{ t.digest_priority }}">{{ t.digest_priority }}</span>{% endif %}
+      </h3>
+      {% if t.digest_category or t.digest_difficulty or t.digest_maturity %}
+      <div class="meta-row">
+        {% if t.digest_category %}카테고리: {{ t.digest_category }}{% endif %}
+        {% if t.digest_difficulty %} · 난이도: {{ t.digest_difficulty }}{% endif %}
+        {% if t.digest_maturity %} · 성숙도: {{ t.digest_maturity }}{% endif %}
+      </div>
+      {% endif %}
+      {% if t.digest_summary %}
+      <div class="summary">{{ t.digest_summary }}</div>
+      {% endif %}
+      {% if t.digest_target_scope %}
+      <div class="scope"><span class="label">적용 대상:</span> {{ t.digest_target_scope }}</div>
+      {% endif %}
+      {% if t.digest_risks %}
+      <div class="risk"><span class="label">리스크:</span> {{ t.digest_risks }}</div>
+      {% endif %}
+      {% if t.news_articles %}
+      <ul class="news">
+        {% for a in t.news_articles %}
+        <li>
+          {% if a.url %}<a href="{{ a.url }}">{{ a.title }}</a>{% else %}{{ a.title }}{% endif %}
+          {% if a.source %}<span class="src-tag">[{{ a.source }}]</span>{% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
 
   <div class="footer">
     StandUp Insight · 주간 자동 발송 ·

--- a/tests/test_tech_topic_synthesis.py
+++ b/tests/test_tech_topic_synthesis.py
@@ -1,0 +1,271 @@
+"""기술 토픽 합성/렌더링 단위 테스트.
+
+- _collect_tech_topics: digest + news 이벤트 그룹핑 로직
+- _build_tech_topic_items: builder 변환
+- 템플릿 렌더링: jinja 가 tech_topics 블록을 정상 처리하는지
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from typing import Any
+
+from app.models.insight import (
+    SOURCE_LOGANALYZER,
+    SOURCE_MEDIUM_DIGEST_REPORT,
+    SOURCE_TECH_NEWS_ARTICLE,
+)
+from app.newsletter.builder import _build_tech_topic_items, render_newsletter
+from app.synthesis.pipeline import (
+    SynthesisOutput,
+    TechTopic,
+    _collect_tech_topics,
+)
+
+
+@dataclass
+class FakeEvent:
+    """IngestionEvent ORM 의 duck-type — 합성 단계에서 쓰는 필드만 흉내."""
+    id: str
+    source_type: str
+    title: str
+    occurred_at: datetime
+    canonical: dict[str, Any] = field(default_factory=dict)
+    source_url: str | None = None
+    service_tag: str | None = None
+    severity: str | None = None
+    category: str | None = None
+    raw_excerpt: str | None = None
+
+
+def _digest_event(
+    *, keyword: str, title: str, priority: str = "",
+    occurred_at: datetime | None = None, event_id: str = "d1",
+    tech_description: str = "tech desc", target_scope: str = "scope",
+    risks: str = "risk text",
+) -> FakeEvent:
+    return FakeEvent(
+        id=event_id,
+        source_type=SOURCE_MEDIUM_DIGEST_REPORT,
+        title=title,
+        occurred_at=occurred_at or datetime(2026, 4, 13, tzinfo=timezone.utc),
+        canonical={
+            "keyword": keyword,
+            "priority": priority,
+            "category": "language-features",
+            "difficulty": "medium",
+            "maturity": "mainstream",
+            "tech_description": tech_description,
+            "target_scope": target_scope,
+            "risks": risks,
+        },
+        source_url="file:///tmp/x.md",
+    )
+
+
+def _news_event(
+    *, keyword: str, title: str, source: str = "google",
+    occurred_at: datetime | None = None, event_id: str = "n1",
+) -> FakeEvent:
+    return FakeEvent(
+        id=event_id,
+        source_type=SOURCE_TECH_NEWS_ARTICLE,
+        title=title,
+        occurred_at=occurred_at or datetime(2026, 4, 13, 12, tzinfo=timezone.utc),
+        canonical={
+            "keyword": keyword,
+            "source": source,
+            "description": "news description",
+        },
+        source_url=f"https://news.example.com/{event_id}",
+    )
+
+
+# ── _collect_tech_topics ─────────────────────────────────────────────────
+def test_collect_tech_topics_groups_by_keyword():
+    events = [
+        _digest_event(keyword="Java 21", title="[Java 21] 적용", event_id="dj"),
+        _news_event(keyword="Java 21", title="Java 21 release", event_id="n1"),
+        _news_event(keyword="Java 21", title="Pattern matching", event_id="n2"),
+        _digest_event(keyword="React 19", title="[React 19] 적용",
+                      priority="high", event_id="dr"),
+    ]
+    topics = _collect_tech_topics(events)
+    by_kw = {t.keyword: t for t in topics}
+    assert set(by_kw.keys()) == {"Java 21", "React 19"}
+    assert len(by_kw["Java 21"].news_articles) == 2
+    assert len(by_kw["React 19"].news_articles) == 0
+
+
+def test_collect_tech_topics_picks_latest_digest_per_keyword():
+    older = _digest_event(
+        keyword="Java",
+        title="old digest",
+        occurred_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+        event_id="old",
+    )
+    newer = _digest_event(
+        keyword="Java",
+        title="new digest",
+        occurred_at=datetime(2026, 4, 13, tzinfo=timezone.utc),
+        event_id="new",
+    )
+    topics = _collect_tech_topics([older, newer])
+    assert len(topics) == 1
+    assert topics[0].digest_title == "new digest"
+    assert topics[0].digest_event_id == "new"
+
+
+def test_collect_tech_topics_news_only_keyword_kept():
+    events = [
+        _news_event(keyword="Spring Boot", title="Spring article 1"),
+    ]
+    topics = _collect_tech_topics(events)
+    assert len(topics) == 1
+    assert topics[0].keyword == "Spring Boot"
+    assert topics[0].digest_title == ""
+    assert len(topics[0].news_articles) == 1
+
+
+def test_collect_tech_topics_orders_by_priority_then_digest_then_news_count():
+    events = [
+        _digest_event(keyword="A", title="a digest", priority="low", event_id="da"),
+        _digest_event(keyword="B", title="b digest", priority="critical", event_id="db"),
+        _digest_event(keyword="C", title="c digest", priority="medium", event_id="dc"),
+    ]
+    topics = _collect_tech_topics(events)
+    keywords_in_order = [t.keyword for t in topics]
+    assert keywords_in_order == ["B", "C", "A"]
+
+
+def test_collect_tech_topics_caps_news_per_keyword():
+    base = datetime(2026, 4, 13, tzinfo=timezone.utc)
+    events = [
+        _digest_event(keyword="X", title="X digest"),
+    ]
+    for i in range(8):
+        events.append(_news_event(
+            keyword="X",
+            title=f"news {i}",
+            occurred_at=base.replace(hour=i),
+            event_id=f"n{i}",
+        ))
+    topics = _collect_tech_topics(events)
+    assert len(topics[0].news_articles) == 5  # 키워드당 최대 5건
+
+
+def test_collect_tech_topics_ignores_non_tech_events():
+    events = [
+        FakeEvent(
+            id="lg1",
+            source_type=SOURCE_LOGANALYZER,
+            title="Some error",
+            occurred_at=datetime(2026, 4, 13, tzinfo=timezone.utc),
+            canonical={"keyword": "Java"},  # 일부러 keyword 가 있어도 무시되어야 함
+        ),
+        _news_event(keyword="Java", title="real java news"),
+    ]
+    topics = _collect_tech_topics(events)
+    assert len(topics) == 1
+    # loganalyzer 이벤트는 카운트되지 않아야 함
+    assert len(topics[0].news_articles) == 1
+
+
+def test_collect_tech_topics_skips_empty_keyword():
+    events = [
+        _news_event(keyword="", title="no keyword"),
+        _news_event(keyword="   ", title="whitespace only"),
+        _news_event(keyword="React", title="real"),
+    ]
+    topics = _collect_tech_topics(events)
+    assert len(topics) == 1
+    assert topics[0].keyword == "React"
+
+
+# ── _build_tech_topic_items ──────────────────────────────────────────────
+def test_build_tech_topic_items_strips_file_url_for_safety():
+    topic = TechTopic(
+        keyword="Java",
+        digest_title="t",
+        digest_url="file:///tmp/x.md",
+    )
+    [item] = _build_tech_topic_items([topic])
+    # file:// 은 외부 발송 메일에서 클릭해도 의미 없으므로 link 로 노출 X
+    assert item["digest_url"] == ""
+
+
+def test_build_tech_topic_items_keeps_https_url():
+    topic = TechTopic(
+        keyword="Java",
+        digest_title="t",
+        digest_url="https://github.com/foo/bar/blob/main/x.md",
+    )
+    [item] = _build_tech_topic_items([topic])
+    assert item["digest_url"].startswith("https://")
+
+
+def test_build_tech_topic_items_lowercases_priority_for_badge_class():
+    topic = TechTopic(keyword="X", digest_priority="HIGH")
+    [item] = _build_tech_topic_items([topic])
+    assert item["digest_priority"] == "high"
+
+
+# ── 템플릿 렌더링 통합 ────────────────────────────────────────────────
+def _make_synthesis(tech_topics: list[TechTopic]) -> SynthesisOutput:
+    return SynthesisOutput(
+        period_start=date(2026, 4, 7),
+        period_end=date(2026, 4, 13),
+        headline="테스트 헤드라인",
+        markdown="# 테스트 헤드라인\n\n## 본문\n간단한 본문",
+        kpis={"total_events": 1, "by_severity": {}, "by_service": {}, "by_source": {}},
+        analysis={"recurring": [], "new": [], "improvements": [], "actions": []},
+        summaries=[],
+        source_event_ids=[],
+        rag_refs=[],
+        tech_topics=tech_topics,
+    )
+
+
+def test_render_newsletter_includes_tech_topic_section():
+    syn = _make_synthesis([TechTopic(
+        keyword="Java 21",
+        digest_title="[Java 21] 적용 제안",
+        digest_priority="high",
+        digest_category="language-features",
+        digest_difficulty="medium",
+        digest_maturity="mainstream",
+        digest_summary="Java 21 의 패턴 매칭 기능 도입",
+        digest_target_scope="새 모듈",
+        digest_risks="호환성 이슈 가능",
+        digest_url="https://example.com/digest.md",
+        news_articles=[
+            {"title": "Java 21 release", "url": "https://news.example.com/r",
+             "source": "google", "description": "...", "published_at": ""},
+        ],
+    )])
+    result = render_newsletter(syn)
+    html = result["html"]
+    assert "이번 주 기술 토픽" in html
+    assert "Java 21" in html
+    assert "[Java 21] 적용 제안" in html
+    assert "badge-high" in html
+    assert "패턴 매칭" in html
+    assert "https://news.example.com/r" in html
+    assert "[google]" in html
+
+
+def test_render_newsletter_omits_section_when_no_topics():
+    syn = _make_synthesis([])
+    result = render_newsletter(syn)
+    assert "이번 주 기술 토픽" not in result["html"]
+
+
+def test_render_newsletter_does_not_emit_anchor_for_file_url():
+    syn = _make_synthesis([TechTopic(
+        keyword="Java",
+        digest_title="title",
+        digest_url="file:///tmp/x.md",
+    )])
+    result = render_newsletter(syn)
+    assert "file:///tmp/x.md" not in result["html"]


### PR DESCRIPTION
## Summary
- PR1 의 TechTrend connector 가 수집한 `medium_digest_report` / `tech_news_article` 이벤트를 키워드 단위로 그룹핑해 SynthesisOutput 에 `tech_topics` 로 노출
- 뉴스레터 템플릿에 '이번 주 기술 토픽' 섹션 신설 (디지스트 1건 + 관련 뉴스 N건, 우선순위 배지)
- `_retrieve_rag_context()` 가 `corpus_tech` 도 검색 대상에 포함

## 의존 관계
- **base**: `feat/tech-trend-pr1` (#69 가 머지된 후 자동으로 main 기준으로 재정렬됨)

## 변경 내역
- `app/synthesis/pipeline.py`
  - `TechTopic` dataclass + `_collect_tech_topics()` (키워드 정규화/케이스 보존, 우선순위 정렬, 키워드당 뉴스 5건 캡)
  - `synthesize()` 가 `tech_topics` + `meta.tech_topic_count` 채움
  - RAG 검색에 `corpus_tech` 추가
- `app/newsletter/builder.py` — `_build_tech_topic_items()` (file:// URL 안전 처리, priority 소문자화)
- `app/templates/insight_newsletter.html` — `.tech-section` 블록, 키워드/우선순위 배지/요약/적용 대상/리스크/뉴스 리스트
- `tests/test_tech_topic_synthesis.py` — 13개 단위 테스트

## 의도된 비범위
- HopenVision 어댑터(`propose_from_tech_topics`) + DevPlan 자동 초안화 + 대시보드 카드는 PR3
- LLM 프롬프트(Stage1/2/3) 변경 없음 — 기술 토픽은 본문(markdown)과 별개의 구조화 섹션으로만 표시 → 안전한 추가형 변경

## Test plan
- [x] `python -m pytest tests/test_tech_topic_synthesis.py tests/test_tech_trend.py` → 25 passed
- [ ] (운영 환경) tech_trend 이벤트가 수집된 상태에서 `POST /api/v1/insight/weekly/run?dry_run=true` 호출 시 HTML 미리보기에 '이번 주 기술 토픽' 섹션이 보이는지
- [ ] tech_trend 가 비활성/이벤트 0건일 때 기존 발송과 동일한 HTML 인지 (회귀 없는지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)