### PR TITLE
feat(tech-trend): HopenVision 자동 제안 + DevPlan 초안화 (PR3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,3 +89,7 @@ TECH_NEWS_TIMEOUT_SEC=15
 # Naver News API (선택 — 미설정 시 Google News RSS 만 사용)
 NAVER_CLIENT_ID=
 NAVER_CLIENT_SECRET=
+
+# 주간 합성 후 tech_topics → HopenVision 제안 + DevPlan 자동 초안화
+TECH_TREND_AUTO_DEV_PLAN=true
+TECH_TREND_MAX_TOPICS_PER_RUN=3

--- a/app/agents_v2/insight_newsletter.py
+++ b/app/agents_v2/insight_newsletter.py
@@ -12,7 +12,7 @@ Insight-Newsletter Agent — 주간 orchestrator.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import Optional
 
@@ -39,6 +39,7 @@ class WeeklyRunResult:
     newsletter_id: str
     send: SendSummary
     indexed_chunks: int
+    tech_topic_proposals: list = field(default_factory=list)
 
 
 def _last_week_window() -> tuple[date, date]:
@@ -112,6 +113,29 @@ def run_weekly(*, dry_run: bool = False, period: Optional[tuple[date, date]] = N
         send_result = send_newsletter(nl_to_send, dry_run=dry_run)
     logger.info("send 완료: %s", send_result)
 
+    # 6. tech_topics → HopenVision 제안 (+ DevPlan 자동 초안화)
+    #    LLM 호출이라 발송 이후로 미루고, 실패해도 주간 흐름은 막지 않는다.
+    tech_proposals: list = []
+    if syn.tech_topics:
+        try:
+            from ..services.hopenvision_proposal_service import (
+                propose_from_tech_topics,
+            )
+            with SessionLocal() as session:
+                tech_proposals = propose_from_tech_topics(
+                    session,
+                    syn.tech_topics,
+                    auto_dev_plan=settings.tech_trend_auto_dev_plan,
+                    max_topics=settings.tech_trend_max_topics_per_run,
+                )
+            logger.info(
+                "tech_topic 제안 %d건 생성 (auto_dev_plan=%s)",
+                len(tech_proposals), settings.tech_trend_auto_dev_plan,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("tech_topic 제안 실패 (파이프라인은 계속): %s", e,
+                           exc_info=True)
+
     logger.info("=== Insight Weekly 종료 ===")
     return WeeklyRunResult(
         period_start=period_start,
@@ -121,6 +145,7 @@ def run_weekly(*, dry_run: bool = False, period: Optional[tuple[date, date]] = N
         newsletter_id=nl_id,
         send=send_result,
         indexed_chunks=indexed,
+        tech_topic_proposals=tech_proposals,
     )
 
 

--- a/app/api/v1/endpoints/dashboard.py
+++ b/app/api/v1/endpoints/dashboard.py
@@ -455,9 +455,12 @@ def insights_page(
     cluster_days: int = Query(default=30, ge=7, le=120),
     db: Session = Depends(get_db),
 ):
-    """Insight 통합 페이지 — ① Tech Digest + ② 토픽 클러스터 + (③ PR3 placeholder)"""
+    """Insight 통합 페이지 — ① Tech Digest + ② 토픽 클러스터 + ③ HopenVision 가이드 + ④ 기술 토픽 자동 제안"""
     from sqlalchemy import select
     from ....services.topic_cluster_service import get_topic_clusters
+    from ....services.hopenvision_proposal_service import (
+        list_tech_topic_proposals,
+    )
 
     nl_q = select(Newsletter).order_by(Newsletter.created_at.desc()).limit(limit)
     newsletters = db.scalars(nl_q).all()
@@ -501,12 +504,21 @@ def insights_page(
         logging.getLogger(__name__).warning("topic clustering 실패: %s", exc)
         topic_clusters = []
 
+    # 섹션 ④ 기술 토픽 자동 제안 (orchestrator 가 주간 합성 후 자동 생성)
+    try:
+        tech_trend_proposals = list_tech_topic_proposals(db, limit=10)
+    except Exception as exc:  # noqa: BLE001
+        import logging
+        logging.getLogger(__name__).warning("tech_trend proposals 조회 실패: %s", exc)
+        tech_trend_proposals = []
+
     return _render(
         "insights.html",
         cards=cards,
         current_severity=severity or "all",
         topic_clusters=topic_clusters,
         cluster_days=cluster_days,
+        tech_trend_proposals=tech_trend_proposals,
         active_page="insights",
     )
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -105,6 +105,14 @@ class Settings(BaseSettings):
     tech_news_workers: int = Field(default=4, env="TECH_NEWS_WORKERS")
     tech_news_timeout_sec: int = Field(default=15, env="TECH_NEWS_TIMEOUT_SEC")
 
+    # 주간 합성 직후 tech_topics 에 대해 HopenVision 제안 + DevPlan 자동 초안화
+    tech_trend_auto_dev_plan: bool = Field(
+        default=True, env="TECH_TREND_AUTO_DEV_PLAN",
+    )
+    tech_trend_max_topics_per_run: int = Field(
+        default=3, env="TECH_TREND_MAX_TOPICS_PER_RUN",
+    )
+
     # Naver News API (선택 — 미설정 시 Google News RSS 만 사용)
     naver_client_id: str = Field(default="", env="NAVER_CLIENT_ID")
     naver_client_secret: str = Field(default="", env="NAVER_CLIENT_SECRET")

--- a/app/services/hopenvision_proposal_service.py
+++ b/app/services/hopenvision_proposal_service.py
@@ -1,19 +1,26 @@
 """
 HopenVision 적용 플랜 제안 서비스 (PR3).
 
-- 입력: topic_cluster_service 의 클러스터 + 최근 hopenvision WorkItem context
-- LLM(exaone3.5) 호출 → 구조화 JSON {diagnosis, candidate_modules, risks, priority}
-- 결과를 hopenvision_proposals 테이블에 캐시
-- 사용자 수락 시 DevPlan 자동 초안화
+두 가지 트리거:
+
+1. **클러스터 기반** (기존, dashboard 수동) — `generate_proposal(cluster_key)`
+   topic_cluster_service 의 클러스터 + 최근 hopenvision WorkItem context →
+   LLM JSON {diagnosis, candidate_modules, risks, priority} → cache → 수락 시 DevPlan.
+
+2. **기술 토픽 기반** (신규, 주간 orchestrator 자동) — `propose_from_tech_topics(topics)`
+   tech_trend connector 가 수집한 Medium Digest + 뉴스 토픽 묶음을 같은 LLM 인터페이스로
+   재사용. cluster_key 는 `tech:<slug>` prefix 로 구분되며, env 옵션에 따라 즉시 DevPlan
+   초안화까지 자동 진행한다.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -26,6 +33,9 @@ from ..models.insight import HopenVisionProposal
 from ..models.issue import WorkItem
 from ..synthesis.ollama_client import chat
 from .topic_cluster_service import get_topic_clusters
+
+if TYPE_CHECKING:
+    from ..synthesis.pipeline import TechTopic
 
 logger = logging.getLogger(__name__)
 
@@ -305,3 +315,248 @@ def get_ai_generated_plan_ids(session: Session) -> set[int]:
                HopenVisionProposal.status == "accepted")
     ).all()
     return {r[0] for r in rows if r[0] is not None}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 기술 토픽 기반 제안 (tech_trend connector + 주간 orchestrator 통합)
+# ─────────────────────────────────────────────────────────────────────────
+
+TECH_TOPIC_KEY_PREFIX = "tech:"
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _tech_topic_cluster_key(keyword: str) -> str:
+    """기술 토픽 키워드 → cluster_key.
+
+    `cluster_key` 컬럼이 String(40) 으로 짧으므로:
+    - 영숫자 외 문자는 `-` 로 정규화하고 32 자로 자른다.
+    - 정규화 결과가 너무 짧으면 sha1 hex 8자 fallback.
+    """
+    base = _SLUG_RE.sub("-", keyword.lower()).strip("-")
+    if len(base) < 3:
+        base = hashlib.sha1(keyword.encode("utf-8")).hexdigest()[:12]
+    base = base[:32]
+    return f"{TECH_TOPIC_KEY_PREFIX}{base}"
+
+
+def _build_tech_topic_summary(topic: "TechTopic") -> dict:
+    """TechTopic → cluster summary 와 호환되는 dict (LLM 프롬프트 입력)."""
+    sample_events: list[dict] = []
+    if topic.digest_title:
+        sample_events.append({
+            "title": topic.digest_title,
+            "severity": (topic.digest_priority or "info"),
+            "category": topic.digest_category or "tech_proposal",
+            "service_tag": None,
+        })
+    for art in topic.news_articles:
+        sample_events.append({
+            "title": art.get("title", ""),
+            "severity": "info",
+            "category": "tech_news",
+            "service_tag": art.get("source"),
+        })
+    return {
+        "keywords": [topic.keyword],
+        "event_count": (1 if topic.digest_title else 0) + len(topic.news_articles),
+        "first_seen": "—",
+        "last_seen": "—",
+        "sample_events": sample_events,
+        # Medium Digest 의 사전 분석을 LLM 프롬프트에 추가로 전달
+        "_extra_context": {
+            "digest_summary": topic.digest_summary,
+            "digest_target_scope": topic.digest_target_scope,
+            "digest_risks": topic.digest_risks,
+            "digest_difficulty": topic.digest_difficulty,
+            "digest_maturity": topic.digest_maturity,
+        },
+    }
+
+
+def _build_tech_topic_user_prompt(
+    summary: dict, hopenvision_context: list[dict],
+) -> str:
+    """tech 토픽 전용 프롬프트 — Medium Digest 의 사전 분석을 hint 로 함께 전달."""
+    parts = ["[수집된 기술 토픽]"]
+    parts.append(f"키워드: {', '.join(summary['keywords'])}")
+    parts.append(f"이벤트 수: {summary['event_count']}건")
+    parts.append("최근 이벤트 샘플:")
+    for ev in summary["sample_events"][:8]:
+        src = f", source={ev.get('service_tag')}" if ev.get('service_tag') else ""
+        parts.append(
+            f"  - [{ev.get('severity', '?')}] {ev.get('title', '')} "
+            f"(category={ev.get('category')}{src})"
+        )
+
+    extra = summary.get("_extra_context") or {}
+    if any(extra.values()):
+        parts.append("")
+        parts.append("[Medium Digest 사전 분석 hint]")
+        if extra.get("digest_summary"):
+            parts.append(f"  설명: {extra['digest_summary']}")
+        if extra.get("digest_target_scope"):
+            parts.append(f"  적용 대상(예시): {extra['digest_target_scope']}")
+        if extra.get("digest_risks"):
+            parts.append(f"  리스크(예시): {extra['digest_risks']}")
+        if extra.get("digest_difficulty"):
+            parts.append(f"  난이도: {extra['digest_difficulty']}")
+        if extra.get("digest_maturity"):
+            parts.append(f"  성숙도: {extra['digest_maturity']}")
+
+    parts.append("")
+    parts.append("[HopenVision 최근 30일 활동 (DB workitem)]")
+    if hopenvision_context:
+        for w in hopenvision_context[:15]:
+            parts.append(f"  - [{w['status']}/{w['category']}] {w['title']}")
+    else:
+        parts.append("  (최근 활동 없음)")
+
+    parts.append("")
+    parts.append(
+        "위 토픽이 HopenVision 에 어떻게 적용될 수 있을지 JSON 으로 제안하라. "
+        "Medium Digest hint 는 외부 사례 — HopenVision 코드베이스에 맞게 재해석할 것."
+    )
+    return "\n".join(parts)
+
+
+def _generate_proposal_for_tech_topic(
+    session: Session,
+    topic: "TechTopic",
+    hopenvision_ctx: list[dict],
+    *,
+    force: bool,
+) -> ProposalResult:
+    cluster_key = _tech_topic_cluster_key(topic.keyword)
+
+    if not force:
+        cached = session.scalars(
+            select(HopenVisionProposal)
+            .where(HopenVisionProposal.cluster_key == cluster_key,
+                   HopenVisionProposal.status.in_(("generated", "accepted")))
+            .order_by(HopenVisionProposal.created_at.desc())
+            .limit(1)
+        ).first()
+        if cached:
+            return ProposalResult(
+                proposal_id=str(cached.id),
+                cluster_key=cluster_key,
+                diagnosis=cached.diagnosis,
+                candidate_modules=cached.candidate_modules or [],
+                risks=cached.risks or [],
+                priority=cached.priority,
+                model=cached.model,
+                eval_ms=cached.eval_ms or 0,
+                status=cached.status,
+                raw_response=cached.raw_response,
+            )
+
+    summary = _build_tech_topic_summary(topic)
+    user_prompt = _build_tech_topic_user_prompt(summary, hopenvision_ctx)
+    model = settings.ollama_model_compose
+
+    gen = chat(
+        model=model,
+        system=_SYSTEM_PROMPT,
+        user=user_prompt,
+        temperature=0.2,
+        max_tokens=1500,
+    )
+    parsed = _parse_llm_json(gen.text) if gen.ok else None
+
+    proposal = HopenVisionProposal(
+        cluster_key=cluster_key,
+        model=model,
+        status="generated" if (gen.ok and parsed) else "failed",
+        cluster_keywords=[topic.keyword],
+        diagnosis=(parsed or {}).get("diagnosis") if parsed else None,
+        candidate_modules=(parsed or {}).get("candidate_modules", []) if parsed else [],
+        risks=(parsed or {}).get("risks", []) if parsed else [],
+        priority=(parsed or {}).get("priority") if parsed else None,
+        raw_response=gen.text,
+        eval_ms=gen.eval_duration_ms,
+    )
+    session.add(proposal)
+    session.flush()
+    session.commit()
+
+    return ProposalResult(
+        proposal_id=str(proposal.id),
+        cluster_key=cluster_key,
+        diagnosis=proposal.diagnosis,
+        candidate_modules=proposal.candidate_modules,
+        risks=proposal.risks,
+        priority=proposal.priority,
+        model=model,
+        eval_ms=gen.eval_duration_ms,
+        status=proposal.status,
+        raw_response=gen.text,
+    )
+
+
+def propose_from_tech_topics(
+    session: Session,
+    topics: list["TechTopic"],
+    *,
+    auto_dev_plan: bool = False,
+    force: bool = False,
+    max_topics: int = 5,
+) -> list[ProposalResult]:
+    """tech_trend 토픽 묶음 → HopenVision 제안 (+옵션상 DevPlan 초안화).
+
+    Args:
+        topics: SynthesisOutput.tech_topics — 키워드 단위로 그룹핑된 토픽
+        auto_dev_plan: True 면 generated 직후 `accept_as_dev_plan` 까지 호출 (DevPlan 초안 생성)
+        force: 캐시 무시하고 재생성
+        max_topics: 1회 호출당 처리할 최대 토픽 수 (LLM 호출 비용 한계)
+
+    Returns:
+        ProposalResult 리스트 (max_topics 만큼). 개별 토픽 실패는 흡수.
+    """
+    if not topics:
+        return []
+
+    try:
+        hopenvision_ctx = _fetch_hopenvision_context(session)
+    except Exception as e:  # noqa: BLE001 — work_items 테이블 없을 수도 있음
+        logger.warning("hopenvision context 조회 실패: %s", e)
+        hopenvision_ctx = []
+
+    results: list[ProposalResult] = []
+    for topic in topics[:max_topics]:
+        try:
+            result = _generate_proposal_for_tech_topic(
+                session, topic, hopenvision_ctx, force=force,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error("tech topic 제안 실패 keyword=%s: %s",
+                         topic.keyword, e, exc_info=True)
+            continue
+
+        if (
+            auto_dev_plan
+            and result.status == "generated"
+            and result.candidate_modules
+        ):
+            try:
+                accept_as_dev_plan(session, result.proposal_id)
+                # 상태가 'accepted' 로 바뀌었으므로 result 도 동기화
+                result.status = "accepted"
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "tech topic DevPlan 자동 초안화 실패 keyword=%s proposal=%s: %s",
+                    topic.keyword, result.proposal_id, e,
+                )
+        results.append(result)
+    return results
+
+
+def list_tech_topic_proposals(
+    session: Session, *, limit: int = 10,
+) -> list[HopenVisionProposal]:
+    """대시보드용 — tech-trend 출처 제안 최근순."""
+    return list(session.scalars(
+        select(HopenVisionProposal)
+        .where(HopenVisionProposal.cluster_key.like(f"{TECH_TOPIC_KEY_PREFIX}%"))
+        .order_by(HopenVisionProposal.created_at.desc())
+        .limit(limit)
+    ))

--- a/app/templates/dashboard/insights.html
+++ b/app/templates/dashboard/insights.html
@@ -358,6 +358,76 @@
     이후 "DevPlan 으로 만들기"를 누르면 <a href="{{ base_path }}/dashboard/dev-plans" style="color:#2563eb;">Dev Plans</a> 화면에 <span style="background:#fef3c7; color:#92400e; padding:1px 6px; border-radius:8px; font-size:11px; font-weight:600;">AI 제안</span> 라벨이 붙은 DRAFT 플랜으로 자동 초안화됩니다.
 </div>
 
+<!-- Section ④: tech-trend (Medium Digest + Google/Naver News) 자동 제안 -->
+<div class="card-header" style="margin-top:32px; margin-bottom:12px;">
+    <h2 style="font-size:15px; color:#1e293b;">④ 기술 토픽 자동 제안 (tech-trend)</h2>
+    <span style="font-size:12px; color:#94a3b8;">주간 합성 시 외부 기술 동향(Java/React 등)에서 자동 생성된 HopenVision 적용 제안</span>
+</div>
+{% if tech_trend_proposals %}
+<div class="topic-grid">
+    {% for p in tech_trend_proposals %}
+    <div class="topic-card">
+        <div class="topic-keywords">
+            {% for kw in p.cluster_keywords %}
+            <span class="topic-kw">{{ kw }}</span>
+            {% endfor %}
+            {% if p.priority %}
+            <span class="topic-kw" style="background:#fef3c7; color:#92400e;">{{ p.priority }}</span>
+            {% endif %}
+            {% if p.status == 'accepted' %}
+            <span class="topic-kw" style="background:#dafbe1; color:#1a7f37;">DevPlan 초안화 완료</span>
+            {% elif p.status == 'failed' %}
+            <span class="topic-kw" style="background:#ffebe9; color:#cf222e;">생성 실패</span>
+            {% endif %}
+        </div>
+        <div class="topic-meta">
+            <span>생성 <b>{{ p.created_at.strftime('%m-%d %H:%M') }}</b></span>
+            <span>모델: {{ p.model }}</span>
+            {% if p.eval_ms %}<span>{{ p.eval_ms }}ms</span>{% endif %}
+        </div>
+        {% if p.diagnosis %}
+        <div style="font-size:13px; color:#1e293b; line-height:1.6; margin:8px 0; padding:8px 10px; background:#f8fafc; border-radius:6px;">
+            {{ p.diagnosis }}
+        </div>
+        {% endif %}
+        {% if p.candidate_modules %}
+        <details>
+            <summary style="font-size:12px; color:#475569; cursor:pointer;">후보 모듈 {{ p.candidate_modules | length }}건</summary>
+            <ul style="font-size:12px; color:#334155; margin:6px 0 0; padding-left:18px;">
+                {% for m in p.candidate_modules %}
+                <li>
+                    <b>{{ m.module }}</b>
+                    {% if m.effort %}<span style="color:#94a3b8;"> · {{ m.effort }}</span>{% endif %}
+                    {% if m.rationale %}<div style="color:#64748b; font-size:11.5px;">{{ m.rationale }}</div>{% endif %}
+                </li>
+                {% endfor %}
+            </ul>
+        </details>
+        {% endif %}
+        {% if p.risks %}
+        <details style="margin-top:6px;">
+            <summary style="font-size:12px; color:#475569; cursor:pointer;">리스크 {{ p.risks | length }}건</summary>
+            <ul style="font-size:11.5px; color:#64748b; margin:6px 0 0; padding-left:18px;">
+                {% for r in p.risks %}
+                <li>{{ r }}</li>
+                {% endfor %}
+            </ul>
+        </details>
+        {% endif %}
+        {% if p.dev_plan_id %}
+        <div style="margin-top:8px; font-size:12px;">
+            → <a href="{{ base_path }}/dashboard/dev-plans/{{ p.dev_plan_id }}" style="color:#2563eb; text-decoration:underline;">DevPlan #{{ p.dev_plan_id }} 보기</a>
+        </div>
+        {% endif %}
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<div class="topic-empty">
+    아직 자동 생성된 기술 토픽 제안이 없습니다. <code style="background:#f6f8fa; padding:1px 5px; border-radius:3px;">TECH_TREND_ENABLED=true</code> 로 설정하고 주간 합성이 한 번 실행되면 여기에 카드가 채워집니다.
+</div>
+{% endif %}
+
 <!-- Preview modal -->
 <div class="ins-modal-bg" id="insModalBg" onclick="if(event.target===this) closePreview()">
     <div class="ins-modal">

--- a/docs/INSIGHT_NEWSLETTER.md
+++ b/docs/INSIGHT_NEWSLETTER.md
@@ -114,6 +114,49 @@ LLM 호출 실패 시: synthesis 가 raw 데이터로 fallback 본문 생성 →
 
 `synthesis_meta.stage{1,2,3}_ms` 로 단계별 시간 측정 가능. 합성 한 번에 보통 30~120초 (M5 24GB 기준).
 
+## tech_trend 채널 (PR1~3) — Medium Digest + 외부 뉴스 → HopenVision 자동 제안
+
+기존 3 source(loganalyzer/github_qa/auto_tobe) 외에 **외부 기술 동향**을 같은 hub 로
+흡수하는 채널이 추가되었다.
+
+```
+[medium-digest-agent reports/*.md] ─┐
+                                     ├─→ TechTrendConnector ─→ corpus_tech
+[Google News RSS / Naver News API] ─┘                                │
+                                                                    ↓
+                                                  Synthesis (변경 없음)
+                                                                    ↓
+                                  SynthesisOutput.tech_topics (키워드별 묶음)
+                                              ↓                     ↓
+                            Newsletter '이번 주 기술 토픽' 섹션      ↓
+                                                                    ↓
+                            HopenVisionProposalService.propose_from_tech_topics()
+                                              ↓
+                            HopenVisionProposal (cluster_key='tech:<slug>')
+                                              ↓
+                                  TECH_TREND_AUTO_DEV_PLAN=true 면
+                                              ↓
+                                          DevPlan(DRAFT) 자동 초안화
+```
+
+핵심 환경변수:
+
+| Key | 기본값 | 설명 |
+|-----|-------|------|
+| `TECH_TREND_ENABLED` | `false` | connector 활성화 |
+| `TECH_TREND_KEYWORDS` | `java,spring,react` | 콤마 구분 검색·필터 키워드 |
+| `MEDIUM_DIGEST_REPORTS_DIR` | `""` | medium-digest-agent 가 만든 `reports/*.md` 경로 |
+| `TECH_NEWS_MAX_PER_KEYWORD` | `5` | 키워드당 뉴스 검색 결과 상한 |
+| `NAVER_CLIENT_ID/SECRET` | `""` | 미설정 시 Google News RSS 만 사용 |
+| `TECH_TREND_AUTO_DEV_PLAN` | `true` | 합성 후 즉시 DevPlan 초안화 |
+| `TECH_TREND_MAX_TOPICS_PER_RUN` | `3` | 1회 합성당 LLM 호출 최대 토픽 수 |
+
+운영 메모:
+- **Gmail 수신은 medium-digest-agent 가 전담** — StandUp 은 산출 markdown 만 import
+- 외부 뉴스 검색은 AllergyInsight 와 동일하게 RSS 기반 (별도 유료 키 불필요)
+- HopenVision 제안 캐시는 `cluster_key=tech:<slug>` 로 클러스터 기반 제안과 분리
+- 대시보드 `/dashboard/insights` 의 ④번 섹션에서 자동 생성된 제안 + DevPlan 링크 확인
+
 ## 향후 확장
 
 1. **자동 효과 검증** (`docs/AGENT_DATA_CONTRACT.md` 참고) — fix 후 재발 여부 자동 라벨

--- a/tests/test_tech_topic_proposals.py
+++ b/tests/test_tech_topic_proposals.py
@@ -1,0 +1,293 @@
+"""tech-trend → HopenVision 제안 어댑터 단위 테스트.
+
+DB/LLM 외부 의존은 모킹.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.hopenvision_proposal_service import (
+    TECH_TOPIC_KEY_PREFIX,
+    _build_tech_topic_summary,
+    _build_tech_topic_user_prompt,
+    _tech_topic_cluster_key,
+    propose_from_tech_topics,
+)
+from app.synthesis.pipeline import TechTopic
+
+
+# ── _tech_topic_cluster_key ──────────────────────────────────────────────
+def test_cluster_key_normalizes_keyword():
+    assert _tech_topic_cluster_key("Java 21+") == "tech:java-21"
+    assert _tech_topic_cluster_key("React 19").startswith("tech:react-19")
+
+
+def test_cluster_key_truncates_to_40_chars_total():
+    huge = "Spring " * 20
+    key = _tech_topic_cluster_key(huge)
+    assert key.startswith(TECH_TOPIC_KEY_PREFIX)
+    assert len(key) <= 40
+
+
+def test_cluster_key_falls_back_to_hash_when_normalized_too_short():
+    # 한글만 있어 정규식이 모두 떨궈내는 경우 해시 fallback
+    key = _tech_topic_cluster_key("자바")
+    assert key.startswith(TECH_TOPIC_KEY_PREFIX)
+    assert len(key) > len(TECH_TOPIC_KEY_PREFIX) + 3
+
+
+def test_cluster_key_stable_for_same_keyword():
+    a = _tech_topic_cluster_key("Java 21")
+    b = _tech_topic_cluster_key("Java 21")
+    assert a == b
+
+
+# ── _build_tech_topic_summary ────────────────────────────────────────────
+def test_summary_counts_digest_and_news_events():
+    topic = TechTopic(
+        keyword="Java",
+        digest_title="[Java] 적용 제안",
+        digest_priority="high",
+        digest_summary="설명",
+        news_articles=[
+            {"title": "n1", "url": "u1", "source": "google",
+             "description": "", "published_at": ""},
+            {"title": "n2", "url": "u2", "source": "naver",
+             "description": "", "published_at": ""},
+        ],
+    )
+    s = _build_tech_topic_summary(topic)
+    assert s["keywords"] == ["Java"]
+    assert s["event_count"] == 3
+    titles = [e["title"] for e in s["sample_events"]]
+    assert "[Java] 적용 제안" in titles
+    assert "n1" in titles and "n2" in titles
+    assert s["_extra_context"]["digest_summary"] == "설명"
+
+
+def test_summary_handles_news_only_topic():
+    topic = TechTopic(
+        keyword="React",
+        news_articles=[
+            {"title": "r1", "url": "", "source": "google",
+             "description": "", "published_at": ""},
+        ],
+    )
+    s = _build_tech_topic_summary(topic)
+    assert s["event_count"] == 1
+    # digest 없음 — sample_events 에 첫 항목이 news 여야 함
+    assert s["sample_events"][0]["title"] == "r1"
+
+
+# ── _build_tech_topic_user_prompt ────────────────────────────────────────
+def test_user_prompt_includes_digest_hint_and_hopenvision_context():
+    summary = {
+        "keywords": ["Java"],
+        "event_count": 2,
+        "sample_events": [
+            {"title": "T1", "severity": "high",
+             "category": "language-features", "service_tag": None},
+        ],
+        "_extra_context": {
+            "digest_summary": "Java 설명",
+            "digest_target_scope": "신규 모듈",
+            "digest_risks": "호환성",
+            "digest_difficulty": "medium",
+            "digest_maturity": "mainstream",
+        },
+    }
+    ctx = [{"title": "기존 작업", "category": "feature", "status": "in_progress"}]
+    prompt = _build_tech_topic_user_prompt(summary, ctx)
+    assert "Java" in prompt
+    assert "T1" in prompt
+    assert "Java 설명" in prompt
+    assert "신규 모듈" in prompt
+    assert "기존 작업" in prompt
+    assert "JSON" in prompt
+
+
+def test_user_prompt_when_no_hint_omits_hint_block():
+    summary = {
+        "keywords": ["X"], "event_count": 1,
+        "sample_events": [{"title": "t", "severity": "info",
+                           "category": "tech_news", "service_tag": "google"}],
+        "_extra_context": {
+            "digest_summary": "", "digest_target_scope": "",
+            "digest_risks": "", "digest_difficulty": "",
+            "digest_maturity": "",
+        },
+    }
+    prompt = _build_tech_topic_user_prompt(summary, [])
+    assert "Medium Digest 사전 분석 hint" not in prompt
+    assert "(최근 활동 없음)" in prompt
+
+
+# ── propose_from_tech_topics 통합 (mock) ────────────────────────────────
+def _fake_chat_result(text: str, ok: bool = True):
+    res = MagicMock()
+    res.ok = ok
+    res.text = text
+    res.eval_duration_ms = 123
+    res.error = None if ok else "boom"
+    return res
+
+
+def test_propose_from_tech_topics_skips_when_empty():
+    session = MagicMock()
+    out = propose_from_tech_topics(session, [], auto_dev_plan=False)
+    assert out == []
+    session.add.assert_not_called()
+
+
+def test_propose_from_tech_topics_generates_per_topic():
+    topics = [
+        TechTopic(keyword="Java"),
+        TechTopic(keyword="React"),
+    ]
+    session = MagicMock()
+    # 캐시 없음
+    session.scalars.return_value.first.return_value = None
+
+    fake_response = '{"diagnosis":"d","candidate_modules":[{"module":"m","rationale":"r","effort":"M"}],"risks":["risk1"],"priority":"P2"}'
+
+    with patch(
+        "app.services.hopenvision_proposal_service._fetch_hopenvision_context",
+        return_value=[],
+    ), patch(
+        "app.services.hopenvision_proposal_service.chat",
+        return_value=_fake_chat_result(fake_response),
+    ):
+        results = propose_from_tech_topics(
+            session, topics, auto_dev_plan=False, max_topics=5,
+        )
+
+    assert len(results) == 2
+    for r in results:
+        assert r.status == "generated"
+        assert r.diagnosis == "d"
+        assert r.priority == "P2"
+        assert r.candidate_modules and r.candidate_modules[0]["module"] == "m"
+    # 토픽 수만큼 add 호출
+    assert session.add.call_count == 2
+
+
+def test_propose_from_tech_topics_respects_max_topics():
+    topics = [TechTopic(keyword=f"kw{i}") for i in range(10)]
+    session = MagicMock()
+    session.scalars.return_value.first.return_value = None
+    fake_response = '{"diagnosis":"d","candidate_modules":[],"risks":[],"priority":"P3"}'
+
+    with patch(
+        "app.services.hopenvision_proposal_service._fetch_hopenvision_context",
+        return_value=[],
+    ), patch(
+        "app.services.hopenvision_proposal_service.chat",
+        return_value=_fake_chat_result(fake_response),
+    ):
+        results = propose_from_tech_topics(
+            session, topics, auto_dev_plan=False, max_topics=2,
+        )
+
+    assert len(results) == 2
+
+
+def test_propose_from_tech_topics_uses_cache_when_not_force():
+    topics = [TechTopic(keyword="Java")]
+    session = MagicMock()
+    cached = MagicMock()
+    cached.id = "cached-id"
+    cached.diagnosis = "cached d"
+    cached.candidate_modules = [{"module": "cm"}]
+    cached.risks = ["cr"]
+    cached.priority = "P1"
+    cached.model = "exaone3.5:7.8b"
+    cached.eval_ms = 50
+    cached.status = "generated"
+    cached.raw_response = "raw"
+    session.scalars.return_value.first.return_value = cached
+
+    with patch(
+        "app.services.hopenvision_proposal_service._fetch_hopenvision_context",
+        return_value=[],
+    ), patch(
+        "app.services.hopenvision_proposal_service.chat",
+    ) as chat_mock:
+        results = propose_from_tech_topics(
+            session, topics, auto_dev_plan=False, force=False,
+        )
+
+    chat_mock.assert_not_called()
+    assert len(results) == 1
+    assert results[0].diagnosis == "cached d"
+    # add 도 호출 안 됨 (캐시 재사용)
+    session.add.assert_not_called()
+
+
+def test_propose_from_tech_topics_auto_dev_plan_invokes_acceptor():
+    topics = [TechTopic(keyword="Java")]
+    session = MagicMock()
+    session.scalars.return_value.first.return_value = None
+    fake_response = '{"diagnosis":"d","candidate_modules":[{"module":"M","effort":"S"}],"risks":[],"priority":"P2"}'
+
+    with patch(
+        "app.services.hopenvision_proposal_service._fetch_hopenvision_context",
+        return_value=[],
+    ), patch(
+        "app.services.hopenvision_proposal_service.chat",
+        return_value=_fake_chat_result(fake_response),
+    ), patch(
+        "app.services.hopenvision_proposal_service.accept_as_dev_plan",
+    ) as accept_mock:
+        results = propose_from_tech_topics(
+            session, topics, auto_dev_plan=True,
+        )
+
+    assert accept_mock.call_count == 1
+    assert results[0].status == "accepted"
+
+
+def test_propose_from_tech_topics_skips_dev_plan_when_no_modules():
+    """candidate_modules 가 비어있으면 DevPlan 생성 자체가 의미 없으므로 호출 X."""
+    topics = [TechTopic(keyword="Java")]
+    session = MagicMock()
+    session.scalars.return_value.first.return_value = None
+    fake_response = '{"diagnosis":"d","candidate_modules":[],"risks":["r"],"priority":"P3"}'
+
+    with patch(
+        "app.services.hopenvision_proposal_service._fetch_hopenvision_context",
+        return_value=[],
+    ), patch(
+        "app.services.hopenvision_proposal_service.chat",
+        return_value=_fake_chat_result(fake_response),
+    ), patch(
+        "app.services.hopenvision_proposal_service.accept_as_dev_plan",
+    ) as accept_mock:
+        propose_from_tech_topics(session, topics, auto_dev_plan=True)
+
+    accept_mock.assert_not_called()
+
+
+def test_propose_from_tech_topics_handles_llm_failure():
+    """LLM 호출 실패 시 'failed' status 로 저장되고 auto_dev_plan 도 안 호출."""
+    topics = [TechTopic(keyword="Java")]
+    session = MagicMock()
+    session.scalars.return_value.first.return_value = None
+
+    with patch(
+        "app.services.hopenvision_proposal_service._fetch_hopenvision_context",
+        return_value=[],
+    ), patch(
+        "app.services.hopenvision_proposal_service.chat",
+        return_value=_fake_chat_result("garbage", ok=False),
+    ), patch(
+        "app.services.hopenvision_proposal_service.accept_as_dev_plan",
+    ) as accept_mock:
+        results = propose_from_tech_topics(
+            session, topics, auto_dev_plan=True,
+        )
+
+    assert results[0].status == "failed"
+    accept_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- PR2 의 `SynthesisOutput.tech_topics` 를 기존 `HopenVisionProposalService` 와 연결
- 주간 합성 직후 LLM 제안을 자동 생성하고, `candidate_modules` 가 있으면 DevPlan(DRAFT) 까지 자동 초안화
- 대시보드 `/dashboard/insights` 에 ④번 '기술 토픽 자동 제안' 섹션 신설

## 의존 관계
- **base**: `feat/tech-trend-pr2` (#70 머지 후 main 기준으로 자동 재정렬)

## 변경 내역
- `app/services/hopenvision_proposal_service.py`
  - `propose_from_tech_topics(session, topics, auto_dev_plan=...)` — 토픽별 LLM 호출 + 캐시 재사용 + 자동 수락
  - `_tech_topic_cluster_key()` — `tech:<slug>` 정규화 (String(40) 컬럼 fit, 한글은 sha1 fallback)
  - `_build_tech_topic_user_prompt()` — Medium Digest 의 사전 분석(target_scope/risks 등)을 LLM 프롬프트의 hint 로 전달
  - `list_tech_topic_proposals()` — 대시보드용 helper
- `app/agents_v2/insight_newsletter.py` — Stage 6 자동 호출 (실패해도 주간 흐름 보호), `WeeklyRunResult.tech_topic_proposals` 추가
- `app/api/v1/endpoints/dashboard.py` + `app/templates/dashboard/insights.html` — ④번 섹션 + 진단/후보 모듈/리스크/DevPlan 링크
- `app/core/config.py` + `.env.example`
  - `TECH_TREND_AUTO_DEV_PLAN=true` (사용자 결정 — DevPlan 자동 초안)
  - `TECH_TREND_MAX_TOPICS_PER_RUN=3` (LLM 호출 비용 한계)
- `docs/INSIGHT_NEWSLETTER.md` — tech_trend 채널 흐름도 + 환경변수 표
- `tests/test_tech_topic_proposals.py` — 15개

## 설계 노트
- **클러스터 기반 제안과 cluster_key 네임스페이스 분리** — 기존 dashboard 의 ②③ 섹션 (수동 트리거) 과 ④ 섹션 (자동) 이 한 테이블에서 LIKE 'tech:%' 로 깔끔히 분리됨
- **LLM 실패 안전** — 자동 흐름에서 chat() 이 실패하면 `status='failed'` 로 저장되고 DevPlan 초안화는 시도하지 않음. 주간 발송은 영향 없음
- **캐시 재사용** — 같은 키워드의 generated/accepted 제안이 있으면 force=True 가 아닌 한 LLM 재호출 없이 cached 결과 반환

## Test plan
- [x] `python -m pytest tests/` → 40 passed (PR1 12 + PR2 13 + PR3 15)
- [ ] (운영) `TECH_TREND_ENABLED=true` + 디지스트 디렉토리 마운트 후 `POST /api/v1/insight/weekly/run` → 응답에 `tech_topic_proposals` 포함, `/dashboard/insights` 에 ④번 카드 노출
- [ ] `TECH_TREND_AUTO_DEV_PLAN=false` 로 두면 제안만 생성되고 DevPlan 은 생기지 않는지
- [ ] `TECH_TREND_ENABLED=false` 일 때 합성 결과가 PR2 와 동일한지 (회귀 없는지)

## 머지 순서 권장
1. PR1 (#69) → main
2. PR2 (#70) → main
3. PR3 (this) → main

🤖 Generated with [Claude Code](https://claude.com/claude-code)