### PR TITLE
feat(hopen-tight): 일일 [HopenTechBrief] cron 채널 (PR6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,3 +109,24 @@ HOPEN_BRIEF_FITNESS_THRESHOLD=60
 
 # repo index 캐시 TTL (시간). 캐시 파일: BASE_DIR/.cache/hopenvision_repo_index.json
 HOPEN_REPO_INDEX_TTL_HOURS=24
+
+# ========================================
+# HopenTechBrief 일일 채널 (PR6)
+# ========================================
+# 일 1회 09:00 KST 카드형 메일 — 게이트(PR4) + detailer(PR5) 통과 토픽만 발송.
+# 별도 수신자 채널: recipients.report_types LIKE '%hopen_tech%' (또는 'all').
+HOPEN_BRIEF_DAILY_ENABLED=false
+HOPEN_BRIEF_DAILY_HOUR=9
+HOPEN_BRIEF_DAILY_MINUTE=0
+
+# 일일 윈도우 — now-N시간 ~ now 의 medium_digest_report + tech_news_article.
+HOPEN_BRIEF_WINDOW_HOURS=24
+
+# 1회 발송에 카드로 표현할 최대 토픽 수 (LLM·외부 fetch 비용 가드).
+HOPEN_BRIEF_MAX_PER_DAY=3
+
+HOPEN_BRIEF_SUBJECT_PREFIX=[HopenTechBrief]
+
+# 주간 newsletter 의 tech 섹션 게이트 — 스택 매칭만 (LLM 호출 없음).
+# 일일 채널은 60+ 통과만 깊이있게 다루므로, 주간은 25 (스택 1개 매칭) 정도로 너그럽게.
+WEEKLY_TECH_STACK_MIN_SCORE=25

--- a/app/agents_v2/hopen_tech_brief.py
+++ b/app/agents_v2/hopen_tech_brief.py
@@ -1,0 +1,301 @@
+"""HopenTechBrief — 일일 cron orchestrator (PR6).
+
+PR4 적합도 게이트와 PR5 detailer 를 *일일* 케이던스로 운영하는 별도 채널.
+주간 Insight Newsletter 와 다음과 같이 분리:
+
+| 항목 | 주간 Insight | **일일 HopenTechBrief** |
+|------|--------------|-------------------------|
+| 윈도우 | 최근 7일 | 최근 24h (env로 조정) |
+| 합성 | exaone3.5 cascade 풀세트 | tech_topics 추출만 |
+| 내용 | LogAnalyzer / GitHub QA / Auto-Tobe 통합 | HopenVision 적용 토픽 한정 |
+| 메일 채널 | report_types LIKE '%insight%' | **report_types LIKE '%hopen_tech%'** |
+| 토픽 깊이 | 키워드 + 디지스트 hint | **+ Mermaid + 사례 + PoC 힌트** |
+| 자동 DevPlan | env 토글 | env 토글 (별도) |
+
+흐름:
+1. IngestionHub.run() 으로 24h 윈도우의 medium_digest_report + tech_news_article 흡수
+2. recent IngestionEvent → `_collect_tech_topics` 로 토픽 묶음
+3. `propose_from_tech_topics` 로 게이트 + detailer + (옵션) DevPlan 초안화
+4. 통과 토픽들로 `hopen_tech_brief.html` 카드 렌더
+5. `report_types LIKE '%hopen_tech%'` 수신자에게 발송
+6. Newsletter 행 저장 (subject prefix 로 일일/주간 구분)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional
+from uuid import UUID
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from pathlib import Path
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..core.config import now_kst, settings
+from ..core.database import SessionLocal
+from ..ingestion.hub import IngestionHub
+from ..models.insight import (
+    IngestionEvent, Newsletter,
+    SOURCE_MEDIUM_DIGEST_REPORT, SOURCE_TECH_NEWS_ARTICLE,
+)
+from ..newsletter.sender import SendSummary, send_hopen_tech_brief
+from ..services.hopenvision_proposal_service import (
+    ProposalResult, propose_from_tech_topics,
+)
+from ..synthesis.pipeline import TechTopic, _collect_tech_topics
+
+logger = logging.getLogger(__name__)
+
+_TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
+_jinja = Environment(
+    loader=FileSystemLoader(str(_TEMPLATE_DIR)),
+    autoescape=select_autoescape(["html", "xml"]),
+)
+
+
+@dataclass
+class DailyBriefResult:
+    period_start: date
+    period_end: date
+    window_hours: int
+    proposals: list[ProposalResult]
+    eligible: int
+    filtered_out: int
+    newsletter_id: Optional[str] = None
+    send: Optional[SendSummary] = None
+    dry_run: bool = False
+    skipped_reason: Optional[str] = None  # "no_eligible_topics" 등
+
+
+# ── 윈도우 + 이벤트 조회 ──────────────────────────────────────────────────
+
+def _window_range(window_hours: int) -> tuple[datetime, datetime]:
+    """now-window ~ now (UTC)."""
+    until = datetime.now(timezone.utc)
+    since = until - timedelta(hours=window_hours)
+    return since, until
+
+
+def _fetch_recent_tech_events(
+    session: Session, since: datetime, until: datetime,
+) -> list[IngestionEvent]:
+    """tech_trend 출처(2종) 만 윈도우로 조회."""
+    q = (
+        select(IngestionEvent)
+        .where(IngestionEvent.occurred_at >= since)
+        .where(IngestionEvent.occurred_at < until)
+        .where(IngestionEvent.source_type.in_(
+            [SOURCE_MEDIUM_DIGEST_REPORT, SOURCE_TECH_NEWS_ARTICLE]
+        ))
+        .order_by(IngestionEvent.occurred_at.desc())
+        .limit(200)
+    )
+    return list(session.scalars(q))
+
+
+# ── 렌더링 ────────────────────────────────────────────────────────────────
+
+def _proposals_to_template_topics(
+    proposals: list[ProposalResult],
+    tech_topics: list[TechTopic],
+) -> list[dict]:
+    """eligible (generated|accepted) 만 카드 dict 로 변환.
+
+    proposals 와 tech_topics 는 같은 keyword 순서로 매칭된다 (propose_from_tech_topics
+    의 결과 순서와 입력 topics 의 순서가 일치한다는 전제).
+    """
+    keyword_to_topic = {t.keyword: t for t in tech_topics}
+    cards: list[dict] = []
+    for p in proposals:
+        if p.status == "filtered_out":
+            continue
+        # cluster_keywords 가 [topic.keyword] 이므로 매칭
+        kw = (p.cluster_key or "").replace("tech:", "", 1) or ""
+        # 화면 표시용 원본 키워드를 tech_topics 에서 회수
+        t = next(
+            (t for t in tech_topics
+             if t.keyword.lower().replace(" ", "-").startswith(kw)),
+            None,
+        )
+        if t is None:
+            # 매칭 실패 시에도 cluster_key 의 slug 를 그대로 사용
+            display_keyword = kw
+            digest_title = ""
+            digest_summary = ""
+        else:
+            display_keyword = t.keyword
+            digest_title = t.digest_title
+            digest_summary = t.digest_summary
+
+        cards.append({
+            "keyword": display_keyword,
+            "priority": (None
+                         if (p.priority or "").lower() not in
+                            ("critical", "high", "medium", "low")
+                         else (p.priority or "").lower()),
+            "impact_area": p.impact_area or "",
+            "fitness_score": p.fitness_score or 0,
+            "effort_hours": p.effort_hours,
+            "digest_title": digest_title,
+            "digest_summary": digest_summary,
+            "diagnosis": p.diagnosis or "",
+            "diagram_mermaid": p.diagram_mermaid or "",
+            "case_studies": p.case_studies or [],
+            "code_hints": p.code_hints or [],
+            "candidate_modules": p.candidate_modules or [],
+            "risks": p.risks or [],
+        })
+    return cards
+
+
+def render_hopen_tech_brief(
+    proposals: list[ProposalResult],
+    tech_topics: list[TechTopic],
+    *,
+    period: date,
+    eligible: int,
+    filtered_out: int,
+) -> dict:
+    """proposals + topics → {subject, headline, html}."""
+    kw_list = [t.keyword for t in tech_topics][:3]
+    keywords_label = ", ".join(kw_list) if kw_list else "(no topics)"
+    subject = (
+        f"{settings.hopen_brief_subject_prefix} "
+        f"{period.isoformat()} · {keywords_label}"
+    )
+    headline = (
+        f"HopenTechBrief — {period.isoformat()} · "
+        f"통과 {eligible}건 / 필터 {filtered_out}건"
+    )
+    template = _jinja.get_template("hopen_tech_brief.html")
+    html = template.render(
+        subject=subject,
+        headline=headline,
+        generated_at=now_kst().strftime("%Y-%m-%d %H:%M KST"),
+        filtered_out_count=filtered_out,
+        topics=_proposals_to_template_topics(proposals, tech_topics),
+    )
+    return {"subject": subject, "headline": headline, "html": html}
+
+
+# ── 메인 진입점 ──────────────────────────────────────────────────────────
+
+def run_daily(
+    *,
+    dry_run: bool = False,
+    window_hours: Optional[int] = None,
+    skip_ingest: bool = False,
+) -> DailyBriefResult:
+    """일일 HopenTechBrief 1회 실행.
+
+    Args:
+        dry_run: True 면 메일 발송 없음 (DB 행은 저장).
+        window_hours: 최근 N시간. None 이면 settings.hopen_brief_window_hours.
+        skip_ingest: True 면 IngestionHub 호출을 건너뛴다 (이미 다른 곳에서 돌린 경우).
+    """
+    wh = window_hours if window_hours is not None else settings.hopen_brief_window_hours
+    today_kst = now_kst().date()
+    logger.info("=== HopenTechBrief Daily 시작 %s (window=%dh, dry_run=%s) ===",
+                today_kst, wh, dry_run)
+
+    # 1) Ingestion (tech_trend connector 만 의미 있음, 다른 채널도 같은 hub 라 함께 실행)
+    if not skip_ingest:
+        try:
+            hub_result = IngestionHub(embed_chunks=True).run()
+            logger.info("daily ingestion: new_events=%d new_chunks=%d",
+                        hub_result.new_events, hub_result.new_chunks)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("daily ingestion 실패 (브리프 계속): %s", e)
+
+    # 2) 24h 윈도우의 tech 이벤트 → tech_topics
+    since, until = _window_range(wh)
+    with SessionLocal() as session:
+        events = _fetch_recent_tech_events(session, since, until)
+
+    tech_topics = _collect_tech_topics(events)
+    logger.info("daily tech_topics 수집: events=%d, topics=%d",
+                len(events), len(tech_topics))
+
+    # 3) 게이트 + detailer + (옵션) DevPlan
+    proposals: list[ProposalResult]
+    with SessionLocal() as session:
+        proposals = propose_from_tech_topics(
+            session,
+            tech_topics,
+            auto_dev_plan=settings.tech_trend_auto_dev_plan,
+            max_topics=settings.hopen_brief_max_per_day,
+        )
+
+    filtered_out = sum(1 for p in proposals if p.status == "filtered_out")
+    eligible = len(proposals) - filtered_out
+    logger.info("daily 결과 — 통과=%d, 필터=%d (threshold=%d)",
+                eligible, filtered_out, settings.hopen_brief_fitness_threshold)
+
+    # 4) 통과 0건이면 발송·저장 skip — 빈 메일 보내지 않음
+    if eligible == 0:
+        logger.info("통과 토픽 없음 — 발송 skip")
+        return DailyBriefResult(
+            period_start=today_kst, period_end=today_kst,
+            window_hours=wh, proposals=proposals,
+            eligible=eligible, filtered_out=filtered_out,
+            dry_run=dry_run, skipped_reason="no_eligible_topics",
+        )
+
+    # 5) 렌더 + 저장
+    rendered = render_hopen_tech_brief(
+        proposals, tech_topics,
+        period=today_kst, eligible=eligible, filtered_out=filtered_out,
+    )
+
+    nl_id: str
+    with SessionLocal() as session:
+        nl = Newsletter(
+            period_start=today_kst,
+            period_end=today_kst,
+            subject=rendered["subject"],
+            headline=rendered["headline"],
+            html_body=rendered["html"],
+            plain_summary=rendered["headline"],
+            source_event_ids=[
+                UUID(str(e.id)) for e in events
+            ],
+            kpis={},
+            synthesis_meta={
+                "channel": "hopen_tech",
+                "window_hours": wh,
+                "eligible": eligible,
+                "filtered_out": filtered_out,
+                "fitness_threshold": settings.hopen_brief_fitness_threshold,
+                "topic_count": len(tech_topics),
+            },
+        )
+        session.add(nl)
+        session.commit()
+        session.refresh(nl)
+        nl_id = str(nl.id)
+
+    # 6) 발송 (hopen_tech 채널 수신자)
+    with SessionLocal() as session:
+        nl_to_send = session.get(Newsletter, nl_id)
+        if nl_to_send is None:
+            raise RuntimeError(f"hopen_tech newsletter {nl_id} missing")
+        send_result = send_hopen_tech_brief(nl_to_send, dry_run=dry_run)
+    logger.info("daily send: %s", send_result)
+
+    return DailyBriefResult(
+        period_start=today_kst, period_end=today_kst,
+        window_hours=wh, proposals=proposals,
+        eligible=eligible, filtered_out=filtered_out,
+        newsletter_id=nl_id, send=send_result, dry_run=dry_run,
+    )
+
+
+def run_daily_job() -> None:
+    """APScheduler wrapper — 예외 흡수."""
+    try:
+        run_daily(dry_run=False)
+    except Exception as e:  # noqa: BLE001
+        logger.error("hopen_tech_brief daily 실패: %s", e, exc_info=True)

--- a/app/agents_v2/insight_newsletter.py
+++ b/app/agents_v2/insight_newsletter.py
@@ -70,6 +70,26 @@ def run_weekly(*, dry_run: bool = False, period: Optional[tuple[date, date]] = N
                 len(syn.source_event_ids),
                 {k: syn.meta.get(k) for k in ("stage1_ms", "stage2_ms", "stage3_ms")})
 
+    # PR6 — 주간 newsletter 의 tech 섹션은 HopenVision 스택 매칭만 통과한 토픽으로
+    # 축약. 일일 [HopenTechBrief] 가 깊이를 다루므로, 주간은 *얕은* 게이트로 무관
+    # 토픽(Autonomous-QA-Agent / 머신비전 등) 만 컷.
+    if syn.tech_topics:
+        from ..services.tech_topic_filter import evaluate_topic
+        original = len(syn.tech_topics)
+        syn.tech_topics = [
+            t for t in syn.tech_topics
+            if evaluate_topic(
+                t, use_llm=False,
+                threshold=settings.weekly_tech_stack_min_score,
+            ).eligible
+        ]
+        if len(syn.tech_topics) < original:
+            logger.info(
+                "weekly tech 섹션 축약: %d → %d (stack threshold=%d)",
+                original, len(syn.tech_topics),
+                settings.weekly_tech_stack_min_score,
+            )
+
     # 3. Render
     rendered = render_newsletter(syn)
 

--- a/app/api/v1/endpoints/insight.py
+++ b/app/api/v1/endpoints/insight.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from ....agents_v2.hopen_tech_brief import run_daily as run_daily_hopen_tech
 from ....agents_v2.insight_newsletter import run_weekly
 from ....core.database import get_db
 from ....ingestion.hub import IngestionHub
@@ -141,3 +142,42 @@ def preview_newsletter(newsletter_id: str, db: Session = Depends(get_db)):
     if nl is None:
         raise HTTPException(404, "newsletter not found")
     return HTMLResponse(content=nl.html_body)
+
+
+# ── HopenTechBrief 일일 채널 (PR6) ───────────────────────────────────────
+
+class HopenBriefRunRequest(BaseModel):
+    dry_run: bool = False
+    window_hours: Optional[int] = None
+    skip_ingest: bool = False
+
+
+class HopenBriefRunResponse(BaseModel):
+    newsletter_id: Optional[str]
+    period: date
+    window_hours: int
+    eligible: int
+    filtered_out: int
+    sent: int
+    failed: int
+    skipped_reason: Optional[str] = None
+
+
+@router.post("/hopen-brief/run", response_model=HopenBriefRunResponse)
+def trigger_hopen_brief(req: HopenBriefRunRequest):
+    """HopenTechBrief 일일 1회 즉시 실행 (수동 트리거 / dry-run)."""
+    res = run_daily_hopen_tech(
+        dry_run=req.dry_run,
+        window_hours=req.window_hours,
+        skip_ingest=req.skip_ingest,
+    )
+    return HopenBriefRunResponse(
+        newsletter_id=res.newsletter_id,
+        period=res.period_start,
+        window_hours=res.window_hours,
+        eligible=res.eligible,
+        filtered_out=res.filtered_out,
+        sent=res.send.success if res.send else 0,
+        failed=res.send.failed if res.send else 0,
+        skipped_reason=res.skipped_reason,
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -128,6 +128,27 @@ class Settings(BaseSettings):
         default=24, env="HOPEN_REPO_INDEX_TTL_HOURS",
     )
 
+    # ── HopenTechBrief 일일 채널 (PR6) ────────────────────────────────────
+    hopen_brief_daily_enabled: bool = Field(
+        default=False, env="HOPEN_BRIEF_DAILY_ENABLED",
+    )
+    hopen_brief_daily_hour: int = Field(default=9, env="HOPEN_BRIEF_DAILY_HOUR")
+    hopen_brief_daily_minute: int = Field(default=0, env="HOPEN_BRIEF_DAILY_MINUTE")
+    hopen_brief_window_hours: int = Field(
+        default=24, env="HOPEN_BRIEF_WINDOW_HOURS",
+    )
+    hopen_brief_max_per_day: int = Field(
+        default=3, env="HOPEN_BRIEF_MAX_PER_DAY",
+    )
+    hopen_brief_subject_prefix: str = Field(
+        default="[HopenTechBrief]", env="HOPEN_BRIEF_SUBJECT_PREFIX",
+    )
+    # 주간 newsletter 의 tech 섹션 게이트 — 스택 매칭만(0~60), LLM 호출 없음.
+    # 일일과 달리 *얕은* 게이트라 더 관대하게 통과 (스택 1개 매칭=25점이면 통과).
+    weekly_tech_stack_min_score: int = Field(
+        default=25, env="WEEKLY_TECH_STACK_MIN_SCORE",
+    )
+
     # Naver News API (선택 — 미설정 시 Google News RSS 만 사용)
     naver_client_id: str = Field(default="", env="NAVER_CLIENT_ID")
     naver_client_secret: str = Field(default="", env="NAVER_CLIENT_SECRET")

--- a/app/core/scheduler.py
+++ b/app/core/scheduler.py
@@ -183,6 +183,21 @@ def setup_scheduler():
             "insight_weekly", "Insight 주간 뉴스레터 발송 (exaone3.5 cascade)",
         )
 
+        # HopenTechBrief — 일일 (PR6). insight 모드 안에서 별도 토글로 제어.
+        if settings.hopen_brief_daily_enabled:
+            from ..agents_v2.hopen_tech_brief import run_daily_job
+
+            _safe_add_job(
+                run_daily_job,
+                CronTrigger(
+                    hour=settings.hopen_brief_daily_hour,
+                    minute=settings.hopen_brief_daily_minute,
+                    timezone=tz,
+                ),
+                "hopen_tech_brief_daily",
+                "HopenTechBrief 일일 카드 메일 발송 (게이트+detailer)",
+            )
+
     scheduler.start()
     logger.info("스케줄러 시작 완료")
 

--- a/app/newsletter/sender.py
+++ b/app/newsletter/sender.py
@@ -41,17 +41,36 @@ def list_insight_recipients(session: Session) -> list[str]:
     return list(rows)
 
 
-def send_newsletter(nl: Newsletter, *, dry_run: bool = False) -> SendSummary:
-    """발송 + sent_at 갱신."""
+def list_hopen_tech_recipients(session: Session) -> list[str]:
+    """HopenTechBrief 일일 발송 채널 — `report_types LIKE '%hopen_tech%'` 또는 'all'."""
+    rows = session.execute(
+        select(Recipient.email)
+        .where(Recipient.is_active.is_(True))
+        .where(
+            (Recipient.report_types == "all")
+            | Recipient.report_types.like("%hopen_tech%")
+        )
+    ).scalars().all()
+    return list(rows)
+
+
+def _send_to_recipients(
+    nl: Newsletter,
+    recipients: list[str],
+    *,
+    dry_run: bool,
+    sender_name: str,
+    channel_label: str,
+) -> SendSummary:
+    """공통 발송 + sent_at 갱신 헬퍼."""
     with SessionLocal() as session:
-        recipients = list_insight_recipients(session)
-        logger.info("insight 수신자 %d 명: %s", len(recipients), recipients)
+        logger.info("%s 수신자 %d 명: %s", channel_label, len(recipients), recipients)
 
         if not recipients:
             return SendSummary(total=0, success=0, failed=0, failures=[])
 
         if dry_run:
-            logger.info("dry_run=True — 실제 발송 안 함")
+            logger.info("dry_run=True — 실제 발송 안 함 (%s)", channel_label)
             return SendSummary(total=len(recipients), success=0, failed=0, failures=[])
 
         service = get_email_service()
@@ -59,13 +78,12 @@ def send_newsletter(nl: Newsletter, *, dry_run: bool = False) -> SendSummary:
             recipients=recipients,
             subject=nl.subject,
             html_content=nl.html_body,
-            sender_name="StandUp Insight",
+            sender_name=sender_name,
         )
 
         success = sum(1 for r in results if r.success)
         failures = [(r.recipient, r.error_message or "") for r in results if not r.success]
 
-        # sent_at 기록 — 일부라도 성공이면 마킹
         if success > 0:
             nl_in_session = session.merge(nl)
             nl_in_session.sent_at = datetime.now(timezone.utc)
@@ -77,3 +95,23 @@ def send_newsletter(nl: Newsletter, *, dry_run: bool = False) -> SendSummary:
             failed=len(failures),
             failures=failures,
         )
+
+
+def send_newsletter(nl: Newsletter, *, dry_run: bool = False) -> SendSummary:
+    """주간 Insight Newsletter 발송 + sent_at 갱신."""
+    with SessionLocal() as session:
+        recipients = list_insight_recipients(session)
+    return _send_to_recipients(
+        nl, recipients, dry_run=dry_run,
+        sender_name="StandUp Insight", channel_label="insight",
+    )
+
+
+def send_hopen_tech_brief(nl: Newsletter, *, dry_run: bool = False) -> SendSummary:
+    """일일 HopenTechBrief 발송 + sent_at 갱신 (PR6)."""
+    with SessionLocal() as session:
+        recipients = list_hopen_tech_recipients(session)
+    return _send_to_recipients(
+        nl, recipients, dry_run=dry_run,
+        sender_name="StandUp HopenTechBrief", channel_label="hopen_tech",
+    )

--- a/docs/INSIGHT_NEWSLETTER.md
+++ b/docs/INSIGHT_NEWSLETTER.md
@@ -222,6 +222,75 @@ PR4 의 적합도 게이트를 통과한 토픽에 대해 *카드형 메일 한 
 
 PR6 에서 일일 cron 으로 이 템플릿을 호출하는 별도 `[HopenTechBrief]` 메일 채널 추가 예정.
 
+## 일일 [HopenTechBrief] 채널 (PR6)
+
+PR4(게이트) + PR5(detailer) 를 *일일 케이던스* 로 운영하는 별도 메일 채널. 주간
+Insight Newsletter 와 다음과 같이 분리되어 공존한다.
+
+| 항목 | 주간 Insight | **일일 HopenTechBrief** |
+|------|--------------|-------------------------|
+| 스케줄 | 월요일 09:00 KST | 매일 09:00 KST |
+| 윈도우 | 최근 7일 | 최근 24h (env 조정) |
+| 합성 | exaone3.5 cascade 풀세트 | tech_topics 추출만 |
+| tech 게이트 | 스택 매칭만 (≥25, 무관 토픽 컷) | 스택+LLM 합산 (≥60, 깊이있게) |
+| 메일 채널 | `report_types LIKE '%insight%'` | `report_types LIKE '%hopen_tech%'` |
+| 토픽 깊이 | 키워드 + 디지스트 hint | + Mermaid + 사례 + PoC 힌트 |
+| 빈 결과 시 | 항상 발송 | 통과 0건이면 발송 skip |
+
+```
+[CRON 09:00 KST]
+  ↓
+IngestionHub (24h 윈도우)
+  ↓
+_collect_tech_topics (medium_digest_report + tech_news_article)
+  ↓
+propose_from_tech_topics
+  ↓ (게이트 통과 토픽 ≥1)
+render_hopen_tech_brief (hopen_tech_brief.html)
+  ↓
+send_hopen_tech_brief (hopen_tech 채널 수신자)
+```
+
+핵심 환경변수 (PR6):
+
+| Key | 기본값 | 설명 |
+|-----|--------|------|
+| `HOPEN_BRIEF_DAILY_ENABLED` | `false` | 일일 cron 활성화 |
+| `HOPEN_BRIEF_DAILY_HOUR` / `_MINUTE` | `9` / `0` | KST 발송 시각 |
+| `HOPEN_BRIEF_WINDOW_HOURS` | `24` | 윈도우 시간 |
+| `HOPEN_BRIEF_MAX_PER_DAY` | `3` | 카드로 표현할 최대 토픽 수 (LLM·fetch 비용 가드) |
+| `HOPEN_BRIEF_SUBJECT_PREFIX` | `[HopenTechBrief]` | 메일 제목 prefix |
+| `WEEKLY_TECH_STACK_MIN_SCORE` | `25` | 주간 newsletter tech 섹션 게이트 (스택만) |
+
+수동 트리거:
+
+```bash
+# 실제 발송
+curl -X POST http://localhost:9060/api/v1/insight/hopen-brief/run \
+  -H "Content-Type: application/json" \
+  -d '{"dry_run": false}'
+
+# dry-run (DB 행은 저장, 메일 미발송)
+curl -X POST http://localhost:9060/api/v1/insight/hopen-brief/run \
+  -H "Content-Type: application/json" \
+  -d '{"dry_run": true, "window_hours": 48}'
+```
+
+수신자 등록:
+
+```sql
+INSERT INTO recipients (name, email, report_types, is_active)
+VALUES ('홍길동', 'a@b.com', 'hopen_tech', true);
+
+-- 기존 수신자에 추가
+UPDATE recipients SET report_types = 'insight,hopen_tech' WHERE email = 'a@b.com';
+```
+
+운영 메모:
+- 같은 `newsletters` 테이블을 재사용 — `synthesis_meta.channel='hopen_tech'` 로 구분, 일일은 `period_start == period_end`.
+- 통과 토픽 0건이면 newsletter row 도 생성하지 않고 빠르게 종료 (`skipped_reason='no_eligible_topics'`).
+- `propose_from_tech_topics` 의 LLM 호출은 토픽당 1~3 회 (게이트 LLM + proposal LLM + detailer 2회). 1일 3토픽 가정 시 최대 12회 LLM 호출.
+
 ## 향후 확장
 
 1. **자동 효과 검증** (`docs/AGENT_DATA_CONTRACT.md` 참고) — fix 후 재발 여부 자동 라벨

--- a/tests/test_hopen_tech_brief.py
+++ b/tests/test_hopen_tech_brief.py
@@ -1,0 +1,335 @@
+"""hopen_tech_brief orchestrator + sender 채널 단위 테스트 (PR6).
+
+DB / LLM / IngestionHub / 메일 발송은 모킹 — 흐름·축약·렌더링 로직 검증.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.agents_v2.hopen_tech_brief import (
+    DailyBriefResult,
+    _proposals_to_template_topics,
+    _window_range,
+    render_hopen_tech_brief,
+    run_daily,
+)
+from app.newsletter.sender import (
+    SendSummary,
+    list_hopen_tech_recipients,
+)
+from app.services.hopenvision_proposal_service import ProposalResult
+from app.synthesis.pipeline import TechTopic
+
+
+# ── _window_range ────────────────────────────────────────────────────────
+
+def test_window_range_returns_recent_n_hours():
+    since, until = _window_range(24)
+    delta = until - since
+    assert 23 <= delta.total_seconds() / 3600 <= 25
+    # tz-aware
+    assert since.tzinfo is not None
+    assert until.tzinfo is not None
+
+
+# ── _proposals_to_template_topics ────────────────────────────────────────
+
+def test_template_topics_skips_filtered_out():
+    topics = [TechTopic(keyword="Spring", digest_title="T1", digest_summary="S1")]
+    proposals = [
+        ProposalResult(
+            proposal_id="p1", cluster_key="tech:spring",
+            diagnosis="d", candidate_modules=[{"module": "M"}], risks=["r"],
+            priority="High", model="m", eval_ms=10, status="generated",
+            raw_response="", fitness_score=78, impact_area="backend-api",
+            effort_hours=6, diagram_mermaid="flowchart LR\nA-->B",
+            case_studies=[{"title": "c1", "url": "https://x"}],
+            code_hints=[{"file": "f.java", "change_sketch": "s"}],
+        ),
+        ProposalResult(
+            proposal_id="", cluster_key="tech:unity",
+            diagnosis=None, candidate_modules=[], risks=[], priority=None,
+            model="", eval_ms=0, status="filtered_out", raw_response=None,
+            fitness_score=10, impact_area="unknown",
+        ),
+    ]
+    cards = _proposals_to_template_topics(proposals, topics)
+    assert len(cards) == 1
+    c = cards[0]
+    assert c["keyword"] == "Spring"
+    assert c["fitness_score"] == 78
+    assert c["impact_area"] == "backend-api"
+    assert c["effort_hours"] == 6
+    assert "flowchart" in c["diagram_mermaid"]
+    assert c["case_studies"][0]["title"] == "c1"
+    assert c["code_hints"][0]["file"] == "f.java"
+    assert c["priority"] == "high"  # 소문자 정규화
+
+
+def test_template_topics_invalid_priority_becomes_none():
+    topics = [TechTopic(keyword="X")]
+    proposals = [
+        ProposalResult(
+            proposal_id="p1", cluster_key="tech:x",
+            diagnosis=None, candidate_modules=[], risks=[], priority="weird",
+            model="m", eval_ms=0, status="generated", raw_response=None,
+        ),
+    ]
+    cards = _proposals_to_template_topics(proposals, topics)
+    assert cards[0]["priority"] is None
+
+
+# ── render_hopen_tech_brief ──────────────────────────────────────────────
+
+def test_render_includes_topic_and_counts():
+    topics = [TechTopic(keyword="Spring Boot", digest_title="T1", digest_summary="S1")]
+    proposals = [
+        ProposalResult(
+            proposal_id="p1", cluster_key="tech:spring-boot",
+            diagnosis="진단", candidate_modules=[{"module": "AdminController"}],
+            risks=["r"], priority="high", model="m", eval_ms=0,
+            status="generated", raw_response=None,
+            fitness_score=78, impact_area="backend-api", effort_hours=4,
+            diagram_mermaid="flowchart LR\nA-->B",
+            case_studies=[], code_hints=[],
+        ),
+    ]
+    rendered = render_hopen_tech_brief(
+        proposals, topics,
+        period=date(2026, 5, 12), eligible=1, filtered_out=2,
+    )
+    assert rendered["subject"].startswith("[HopenTechBrief]")
+    assert "2026-05-12" in rendered["subject"]
+    assert "Spring Boot" in rendered["subject"]
+    assert "통과 1건 / 필터 2건" in rendered["headline"]
+    html = rendered["html"]
+    assert "AdminController" in html
+    assert "flowchart LR" in html
+    assert "78" in html  # fitness_score
+
+
+def test_render_handles_no_topics():
+    rendered = render_hopen_tech_brief(
+        [], [], period=date(2026, 5, 12),
+        eligible=0, filtered_out=0,
+    )
+    assert "(no topics)" in rendered["subject"]
+    assert "통과 0" in rendered["html"] or "임계치" in rendered["html"]
+
+
+# ── run_daily 통합 (DB·LLM·hub·mail 모킹) ───────────────────────────────
+
+def _fake_event(source_type="medium_digest_report"):
+    import uuid
+    e = MagicMock()
+    e.id = uuid.uuid4()
+    e.source_type = source_type
+    e.occurred_at = datetime.now(timezone.utc)
+    return e
+
+
+def test_run_daily_skips_send_when_no_eligible_topics(monkeypatch):
+    """모든 토픽이 filtered_out 이면 발송 skip + skipped_reason 반환."""
+    proposals = [
+        ProposalResult(
+            proposal_id="", cluster_key="tech:x",
+            diagnosis=None, candidate_modules=[], risks=[], priority=None,
+            model="", eval_ms=0, status="filtered_out", raw_response=None,
+            fitness_score=10, impact_area="unknown",
+        ),
+    ]
+    topics = [TechTopic(keyword="X")]
+
+    fake_hub = MagicMock()
+    fake_hub_inst = fake_hub.return_value
+    fake_hub_inst.run.return_value = MagicMock(new_events=0, new_chunks=0)
+
+    with patch(
+        "app.agents_v2.hopen_tech_brief.IngestionHub", fake_hub,
+    ), patch(
+        "app.agents_v2.hopen_tech_brief._fetch_recent_tech_events",
+        return_value=[_fake_event()],
+    ), patch(
+        "app.agents_v2.hopen_tech_brief._collect_tech_topics",
+        return_value=topics,
+    ), patch(
+        "app.agents_v2.hopen_tech_brief.propose_from_tech_topics",
+        return_value=proposals,
+    ), patch(
+        "app.agents_v2.hopen_tech_brief.send_hopen_tech_brief",
+    ) as mail_mock:
+        res = run_daily(dry_run=False)
+
+    assert res.skipped_reason == "no_eligible_topics"
+    assert res.eligible == 0
+    assert res.filtered_out == 1
+    assert res.newsletter_id is None
+    mail_mock.assert_not_called()
+
+
+def test_run_daily_renders_and_sends_when_eligible(monkeypatch, tmp_path):
+    """통과 토픽 ≥1 이면 newsletter 저장 + 발송."""
+    proposals = [
+        ProposalResult(
+            proposal_id="p1", cluster_key="tech:spring",
+            diagnosis="d", candidate_modules=[{"module": "M"}], risks=[],
+            priority="P2", model="m", eval_ms=0,
+            status="generated", raw_response=None,
+            fitness_score=72, impact_area="backend-api", effort_hours=5,
+        ),
+    ]
+    topics = [TechTopic(keyword="Spring", digest_title="T1", digest_summary="S1")]
+
+    fake_hub = MagicMock()
+    fake_hub.return_value.run.return_value = MagicMock(new_events=0, new_chunks=0)
+
+    # SessionLocal 의 instance 가 여러 번 생성되므로 last_nl 을 closure 로 공유
+    state = {"last_nl": None}
+
+    class FakeSession:
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def add(self, obj):
+            obj.id = "nl-uuid-1"
+            state["last_nl"] = obj
+        def commit(self): pass
+        def refresh(self, obj): pass
+        def get(self, model, oid): return state["last_nl"]
+
+    fake_session_factory = MagicMock(side_effect=lambda: FakeSession())
+
+    send_summary = SendSummary(total=1, success=1, failed=0, failures=[])
+
+    with patch(
+        "app.agents_v2.hopen_tech_brief.IngestionHub", fake_hub,
+    ), patch(
+        "app.agents_v2.hopen_tech_brief.SessionLocal", fake_session_factory,
+    ), patch(
+        "app.agents_v2.hopen_tech_brief._fetch_recent_tech_events",
+        return_value=[_fake_event()],
+    ), patch(
+        "app.agents_v2.hopen_tech_brief._collect_tech_topics",
+        return_value=topics,
+    ), patch(
+        "app.agents_v2.hopen_tech_brief.propose_from_tech_topics",
+        return_value=proposals,
+    ), patch(
+        "app.agents_v2.hopen_tech_brief.send_hopen_tech_brief",
+        return_value=send_summary,
+    ) as mail_mock:
+        res = run_daily(dry_run=False)
+
+    assert res.eligible == 1
+    assert res.filtered_out == 0
+    assert res.newsletter_id == "nl-uuid-1"
+    assert res.send.success == 1
+    mail_mock.assert_called_once()
+
+
+def test_run_daily_skip_ingest_does_not_call_hub():
+    fake_hub = MagicMock()
+    with patch(
+        "app.agents_v2.hopen_tech_brief.IngestionHub", fake_hub,
+    ), patch(
+        "app.agents_v2.hopen_tech_brief._fetch_recent_tech_events",
+        return_value=[],
+    ), patch(
+        "app.agents_v2.hopen_tech_brief._collect_tech_topics",
+        return_value=[],
+    ), patch(
+        "app.agents_v2.hopen_tech_brief.propose_from_tech_topics",
+        return_value=[],
+    ):
+        res = run_daily(dry_run=True, skip_ingest=True)
+
+    fake_hub.assert_not_called()
+    assert res.eligible == 0
+    assert res.skipped_reason == "no_eligible_topics"
+
+
+# ── sender — hopen_tech 채널 ─────────────────────────────────────────────
+
+def test_list_hopen_tech_recipients_matches_pattern():
+    """`report_types` 가 'hopen_tech' / 'all' / 'insight,hopen_tech' 인 활성 사용자만."""
+    from app.models.recipient import Recipient
+
+    # SQLAlchemy session.execute 흐름을 모킹
+    session = MagicMock()
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = ["a@x.com", "b@x.com"]
+    session.execute.return_value.scalars.return_value = scalars_mock
+
+    result = list_hopen_tech_recipients(session)
+    assert result == ["a@x.com", "b@x.com"]
+
+    # 실제 SQL 호출이 하나 발생했고, WHERE 조건에 'hopen_tech' 또는 'all' 이 포함
+    call = session.execute.call_args[0][0]
+    compiled = str(call.compile(compile_kwargs={"literal_binds": True}))
+    assert "hopen_tech" in compiled
+    assert "recipients.is_active" in compiled
+
+
+# ── weekly 축약 검증 (insight_newsletter 흐름 단편) ─────────────────────
+
+def test_weekly_filters_tech_topics_with_stack_only_gate(monkeypatch):
+    """run_weekly 가 호출되면 stack-only 게이트로 syn.tech_topics 축약."""
+    from app.agents_v2 import insight_newsletter as agent
+    from app.synthesis.pipeline import SynthesisOutput
+
+    # synthesize 가 반환할 가짜 결과
+    fake_syn = SynthesisOutput(
+        period_start=date(2026, 5, 5), period_end=date(2026, 5, 11),
+        headline="h", markdown="# h", kpis={}, analysis={},
+        summaries=[], source_event_ids=[], rag_refs=[],
+        tech_topics=[
+            TechTopic(keyword="Spring", digest_summary="spring boot api"),
+            TechTopic(keyword="Unity Engine", digest_summary="game shader"),
+        ],
+    )
+
+    fake_hub_result = MagicMock(per_connector={}, new_events=0, new_chunks=0)
+    fake_send = SendSummary(total=0, success=0, failed=0, failures=[])
+
+    # weekly 흐름에서 외부 효과 모킹
+    with patch.object(agent, "IngestionHub") as hub_cls, patch.object(
+        agent, "synthesize", return_value=fake_syn,
+    ), patch.object(
+        agent, "render_newsletter",
+        return_value={"subject": "S", "headline": "H",
+                       "html": "<p>x</p>", "plain_summary": "p"},
+    ), patch.object(
+        agent, "SessionLocal",
+    ) as session_cls, patch.object(
+        agent, "send_newsletter", return_value=fake_send,
+    ), patch.object(
+        agent, "index_newsletter", return_value=0,
+    ), patch.object(
+        agent.settings, "tech_trend_auto_dev_plan", False,
+    ), patch.object(
+        agent.settings, "weekly_tech_stack_min_score", 25,
+    ), patch.object(
+        agent.settings, "hopenvision_stack_tags",
+        "java,spring,react,postgresql,typescript",
+    ):
+        hub_cls.return_value.run.return_value = fake_hub_result
+        # SessionLocal() 컨텍스트
+        sess = MagicMock()
+        sess.__enter__.return_value = sess
+        sess.__exit__.return_value = False
+        sess.add = MagicMock()
+        sess.commit = MagicMock()
+        nl_obj = MagicMock()
+        nl_obj.id = "nl-id-1"
+        sess.refresh.side_effect = lambda obj: setattr(obj, "id", "nl-id-1")
+        sess.get.return_value = nl_obj
+        session_cls.return_value = sess
+
+        result = agent.run_weekly(dry_run=True)
+
+    # Spring 만 남고 Unity 는 컷
+    keywords = [t.keyword for t in result.synthesis.tech_topics]
+    assert keywords == ["Spring"]


### PR DESCRIPTION
## Summary
- **일일 케이던스 채널 신설**: PR4 게이트 + PR5 detailer 를 매일 09:00 KST 에 실행해 통과 토픽 1~3건을 카드형 메일로 발송. 주간 Insight Newsletter 와 같은 SMTP/DB 인프라 공유, 수신자 채널만 분리 (`report_types LIKE '%hopen_tech%'`).
- **빈 결과 시 무발송**: 적합도 게이트 통과 0건이면 newsletter row 생성도 건너뛰고 `skipped_reason='no_eligible_topics'` 반환.
- **주간 newsletter 자동 축약**: 일일 채널이 깊이를 다루므로 주간 tech 섹션은 *얕은* 스택 매칭 게이트(LLM 호출 없음)로 무관 토픽(Autonomous-QA-Agent / 머신비전 / 게임엔진 등)만 제거.
- **수동 트리거 API**: `POST /api/v1/insight/hopen-brief/run` — `dry_run / window_hours / skip_ingest` 옵션.

## 변경 모듈
| 종류 | 파일 |
|---|---|
| 신규 | `app/agents_v2/hopen_tech_brief.py` (260 LoC, run_daily orchestrator) |
| 신규 | `tests/test_hopen_tech_brief.py` (10 케이스) |
| 변경 | `app/newsletter/sender.py` (list_hopen_tech_recipients + send_hopen_tech_brief, _send_to_recipients 헬퍼) |
| 변경 | `app/api/v1/endpoints/insight.py` (POST /hopen-brief/run) |
| 변경 | `app/core/scheduler.py` (HOPEN_BRIEF_DAILY_ENABLED 토글로 cron 등록) |
| 변경 | `app/agents_v2/insight_newsletter.py` (주간 tech 섹션 stack-only 축약) |
| 변경 | `app/core/config.py` + `.env.example` + `docs/INSIGHT_NEWSLETTER.md` |

## 새 환경변수
```bash
HOPEN_BRIEF_DAILY_ENABLED=false      # 기본 off — 운영 시 true 로
HOPEN_BRIEF_DAILY_HOUR=9
HOPEN_BRIEF_DAILY_MINUTE=0
HOPEN_BRIEF_WINDOW_HOURS=24
HOPEN_BRIEF_MAX_PER_DAY=3
HOPEN_BRIEF_SUBJECT_PREFIX=[HopenTechBrief]
WEEKLY_TECH_STACK_MIN_SCORE=25       # 주간 tech 섹션 게이트 (스택 1개 매칭=25)
```

## 채널 분리 요약
| 항목 | 주간 Insight | **일일 HopenTechBrief** |
|------|--------------|-------------------------|
| 윈도우 | 7일 | 24h |
| tech 게이트 | 스택 매칭만 (≥25, 무관 토픽 컷) | 스택+LLM 합산 (≥60, 깊이있게) |
| 수신자 | `'%insight%'` | `'%hopen_tech%'` |
| 깊이 | 키워드+디지스트 hint | + Mermaid + 사례 + PoC 힌트 |

## 로컬 검증
- 전체 테스트 94 passed (PR6 신규 10 + 기존 84)
- FastAPI router 등록: `POST /insight/hopen-brief/run` 확인
- 의존성·import 그래프 깨끗 (smoke 테스트 OK)
- alembic head 변동 없음 (DB 스키마 변경 없음)

## 운영 수신자 등록
```sql
INSERT INTO recipients (name, email, report_types, is_active)
VALUES ('홍길동', 'a@b.com', 'hopen_tech', true);

UPDATE recipients SET report_types = 'insight,hopen_tech' WHERE email = 'a@b.com';
```

## Test plan
- [ ] `.env` 에 `HOPEN_BRIEF_DAILY_ENABLED=true` 설정 후 앱 재시작 → 스케줄 작업 `hopen_tech_brief_daily` 가 9시로 등록되는지 로그 확인
- [ ] dry-run 으로 즉시 호출 → newsletter row 저장 + 메일 미발송 확인:
      `curl -X POST http://localhost:9060/api/v1/insight/hopen-brief/run -H 'Content-Type: application/json' -d '{"dry_run": true}'`
- [ ] `report_types='hopen_tech'` 수신자 1명 등록 후 실제 발송 1회 확인
- [ ] 주간 newsletter (월요일 09:00) 의 tech 섹션이 무관 토픽 없이 축약되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)