### PR TITLE
feat(hopen-tight): 운영 마운트 + deploy.yml 토글 (PR7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,12 @@ TECH_TREND_MAX_TOPICS_PER_RUN=3
 # ========================================
 # HopenVision 레포 로컬 clone 경로. 인덱서가 controller/entity/page 메타를
 # 추출해 LLM 프롬프트에 주입 + 적합도 점수에 사용.
+#
+# 운영(Docker, docker-compose.production.yml) 에서는 다음 마운트가 적용되어
+# 컨테이너 안에서는 /data/hopenvision 로 참조:
+#   /Users/rainend/GIT/hopenvision  →  /data/hopenvision (ro)
+# medium-digest 도 동일하게:
+#   /Users/rainend/GIT/medium-digest-agent/reports  →  /data/medium-digest (ro)
 HOPENVISION_REPO_PATH=/Users/rainend/GIT/hopenvision
 
 # 토픽 텍스트와 매칭할 스택 태그 (콤마 구분).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,12 @@ jobs:
           MONTHLY_REPORT_HOUR: ${{ vars.MONTHLY_REPORT_HOUR }}
           MONTHLY_REPORT_MINUTE: ${{ vars.MONTHLY_REPORT_MINUTE }}
           LOG_LEVEL: ${{ vars.LOG_LEVEL }}
+          # PR7 — tech_trend / HopenVision (vars 로 운영자 토글 가능). 기본은 안전한 off.
+          STANDUP_MODE: ${{ vars.STANDUP_MODE }}
+          TECH_TREND_ENABLED: ${{ vars.TECH_TREND_ENABLED }}
+          TECH_TREND_KEYWORDS: ${{ vars.TECH_TREND_KEYWORDS }}
+          HOPEN_BRIEF_DAILY_ENABLED: ${{ vars.HOPEN_BRIEF_DAILY_ENABLED }}
+          HOPEN_BRIEF_FITNESS_THRESHOLD: ${{ vars.HOPEN_BRIEF_FITNESS_THRESHOLD }}
         run: |
           cat > .env.production << EOF
           DATABASE_URL=${DATABASE_URL}
@@ -49,6 +55,17 @@ jobs:
           MONTHLY_REPORT_MINUTE=${MONTHLY_REPORT_MINUTE:-0}
           LOG_LEVEL=${LOG_LEVEL:-INFO}
           API_PORT=9060
+
+          # ── PR7 — tech_trend / HopenVision (모드·게이트 토글) ───────────
+          STANDUP_MODE=${STANDUP_MODE:-both}
+          TECH_TREND_ENABLED=${TECH_TREND_ENABLED:-true}
+          TECH_TREND_KEYWORDS=${TECH_TREND_KEYWORDS:-java,spring,react,postgresql,typescript}
+          # 컨테이너 안에서 마운트 결과 경로 (docker-compose.production.yml volumes 와 매칭).
+          MEDIUM_DIGEST_REPORTS_DIR=/data/medium-digest
+          HOPENVISION_REPO_PATH=/data/hopenvision
+          # 일일 [HopenTechBrief] cron — vars 로 즉시 ON/OFF (PR8 에서 true 로 전환 예정).
+          HOPEN_BRIEF_DAILY_ENABLED=${HOPEN_BRIEF_DAILY_ENABLED:-false}
+          HOPEN_BRIEF_FITNESS_THRESHOLD=${HOPEN_BRIEF_FITNESS_THRESHOLD:-60}
           EOF
 
       - name: Run deploy script

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -13,6 +13,11 @@ services:
       - ROOT_PATH=/standup
     volumes:
       - ./logs:/app/logs
+      # PR7 — tech_trend + HopenVision 입력 마운트 (운영 MacBook 절대 경로).
+      # 컨테이너 안에서는 /data/* 로 일관 참조 — .env 의 MEDIUM_DIGEST_REPORTS_DIR
+      # / HOPENVISION_REPO_PATH 와 1:1 매칭.
+      - /Users/rainend/GIT/medium-digest-agent/reports:/data/medium-digest:ro
+      - /Users/rainend/GIT/hopenvision:/data/hopenvision:ro
     restart: always
     networks:
       - app-network

--- a/docs/INSIGHT_NEWSLETTER.md
+++ b/docs/INSIGHT_NEWSLETTER.md
@@ -291,6 +291,37 @@ UPDATE recipients SET report_types = 'insight,hopen_tech' WHERE email = 'a@b.com
 - 통과 토픽 0건이면 newsletter row 도 생성하지 않고 빠르게 종료 (`skipped_reason='no_eligible_topics'`).
 - `propose_from_tech_topics` 의 LLM 호출은 토픽당 1~3 회 (게이트 LLM + proposal LLM + detailer 2회). 1일 3토픽 가정 시 최대 12회 LLM 호출.
 
+## 운영 적용 (PR7) — 마운트·deploy.yml 토글
+
+운영 컨테이너(`docker-compose.production.yml` + `.github/workflows/deploy.yml`)
+에서 tech_trend 입력과 HopenVision 게이트 컨텍스트를 동작시키려면 호스트 경로를
+컨테이너로 마운트해야 한다. PR7 부터 다음 마운트가 적용:
+
+```yaml
+volumes:
+  - ./logs:/app/logs
+  - /Users/rainend/GIT/medium-digest-agent/reports:/data/medium-digest:ro
+  - /Users/rainend/GIT/hopenvision:/data/hopenvision:ro
+```
+
+`deploy.yml` 의 `.env.production` 생성부에 다음 7개 변수가 추가됨:
+
+| 변수 | 기본값 (vars 미설정 시) | GH vars 로 토글 |
+|------|-----------------------|-----------------|
+| `STANDUP_MODE` | `both` | ✅ |
+| `TECH_TREND_ENABLED` | `true` | ✅ |
+| `TECH_TREND_KEYWORDS` | `java,spring,react,postgresql,typescript` | ✅ |
+| `MEDIUM_DIGEST_REPORTS_DIR` | `/data/medium-digest` (마운트 경로 고정) | ❌ |
+| `HOPENVISION_REPO_PATH` | `/data/hopenvision` (마운트 경로 고정) | ❌ |
+| `HOPEN_BRIEF_DAILY_ENABLED` | `false` | ✅ (PR8 에서 true 전환 예정) |
+| `HOPEN_BRIEF_FITNESS_THRESHOLD` | `60` | ✅ |
+
+운영 토글 절차:
+1. **GitHub repo → Settings → Secrets and variables → Actions → Variables 탭**
+2. `HOPEN_BRIEF_DAILY_ENABLED` 등 vars 추가/변경
+3. `prod` 브랜치에 빈 commit push 또는 main→prod 머지로 Deploy 워크플로 재실행
+4. 새 컨테이너 healthz + `GET /api/v1/health` 의 `scheduler.jobs` 에서 `hopen_tech_brief_daily` 등록 확인
+
 ## 향후 확장
 
 1. **자동 효과 검증** (`docs/AGENT_DATA_CONTRACT.md` 참고) — fix 후 재발 여부 자동 라벨


### PR DESCRIPTION
## Summary
- **PR4~6 코드는 운영 안착했지만 입력 데이터가 없어 dry-run 이 항상 0건**. 호스트 경로를 컨테이너로 마운트하고 deploy.yml 의 `.env.production` 생성부에 토글 변수를 추가해 실제 파이프라인을 동작시킴.
- **코드 변경 없음** — 인프라/배포/문서만. 테스트 94 passed 그대로.

## 변경
| 파일 | 변경 |
|---|---|
| `docker-compose.production.yml` | volumes 2개 추가 (read-only): medium-digest reports / hopenvision clone |
| `.github/workflows/deploy.yml` | `.env.production` 생성부에 7개 변수 추가 (5개는 GH vars 토글, 2개는 마운트 경로 고정) |
| `.env.example` | 운영 마운트 컨벤션 코멘트 |
| `docs/INSIGHT_NEWSLETTER.md` | 운영 적용 섹션 + vars 토글 절차 |

## 운영 토글 (PR7 후)
GitHub repo → Settings → Secrets and variables → Actions → Variables 탭에서 즉시 조정:

| 변수 | 기본값 | 비고 |
|---|---|---|
| `STANDUP_MODE` | `both` | legacy/insight 모드 분기 |
| `TECH_TREND_ENABLED` | `true` | medium-digest + 뉴스 connector |
| `TECH_TREND_KEYWORDS` | `java,spring,react,postgresql,typescript` | HopenVision 스택 매칭용 |
| `HOPEN_BRIEF_DAILY_ENABLED` | `false` | **PR8 에서 true 로 전환 예정** |
| `HOPEN_BRIEF_FITNESS_THRESHOLD` | `60` | 게이트 임계점 |

마운트 경로 두 개는 yml 안에 고정 (호스트 절대 경로 ↔ 컨테이너 `/data/*`).

## Test plan
- [ ] PR 머지 후 prod 머지로 Deploy 워크플로 자동 실행
- [ ] 새 컨테이너 healthy 확인
- [ ] 컨테이너 안에서 마운트 검증:
      `docker exec standup-app ls /data/medium-digest | head` (markdown 파일들 노출)
      `docker exec standup-app ls /data/hopenvision` (api/web-admin/web-user 등)
- [ ] `POST /api/v1/insight/hopen-brief/run` dry-run 호출 → tech_trend connector 가 실행되어 eligible/filtered_out 분포가 0/0 이 아닌지 확인
- [ ] eligible ≥ 1 이면 dry-run 응답에서 `newsletter_id` 반환 + DB 의 `hopenvision_proposals` 에 행 누적 시작 확인

## 다음 단계 (PR8 예고)
PR7 검증 후 `HOPEN_BRIEF_DAILY_ENABLED=true` 로 GH vars 변경 → prod 재배포 → 매일 09:00 KST 자동 발송 시작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)