### PR TITLE
fix(infra): Ollama·LogAnalyzer httpx 호출 프록시 우회 (PR8)

### DIFF
--- a/app/ingestion/connectors/loganalyzer.py
+++ b/app/ingestion/connectors/loganalyzer.py
@@ -37,7 +37,8 @@ class LogAnalyzerConnector(Connector):
 
     def _get(self, path: str, **params) -> Any:
         url = f"{self.base_url}{path}"
-        with httpx.Client(timeout=30.0) as client:
+        # trust_env=False — OrbStack 등 호스트 proxy 가 내부 호스트 호출까지 가로채는 사고 방지.
+        with httpx.Client(timeout=30.0, trust_env=False) as client:
             r = client.get(url, params=params)
             r.raise_for_status()
             return r.json()

--- a/app/rag/embedder.py
+++ b/app/rag/embedder.py
@@ -42,7 +42,7 @@ def _embed_one(client: httpx.Client, text: str) -> list[float] | None:
 
 def embed_texts(texts: Iterable[str]) -> list[list[float] | None]:
     out: list[list[float] | None] = []
-    with httpx.Client() as client:
+    with httpx.Client(trust_env=False) as client:
         for t in texts:
             out.append(_embed_one(client, t))
     return out
@@ -62,7 +62,7 @@ def embed_pending_chunks(batch_size: int = 64) -> int:
             if not chunks:
                 break
 
-            with httpx.Client() as client:
+            with httpx.Client(trust_env=False) as client:
                 for ch in chunks:
                     emb = _embed_one(client, ch.chunk_text[:8000])
                     if emb is None:

--- a/app/synthesis/ollama_client.py
+++ b/app/synthesis/ollama_client.py
@@ -51,7 +51,13 @@ def chat(
         },
     }
     try:
-        with httpx.Client(timeout=timeout or settings.ollama_timeout_sec) as client:
+        # trust_env=False — OrbStack 등 호스트 환경의 HTTPS_PROXY/HTTP_PROXY 가
+        # Ollama 호출까지 가로채는 사고 방지. Ollama 는 보통 같은 호스트
+        # (host.docker.internal:11434) 에 있어 프록시를 거치면 안 된다.
+        with httpx.Client(
+            timeout=timeout or settings.ollama_timeout_sec,
+            trust_env=False,
+        ) as client:
             r = client.post(url, json=payload)
             r.raise_for_status()
             data = r.json()


### PR DESCRIPTION
## Summary
PR7 운영 적용 검증 중 발견한 사일런트 회귀 hotfix. OrbStack 이 컨테이너에 자동 주입하는 `HTTPS_PROXY` 가 `host.docker.internal:11434` 같은 *내부 호스트 호출까지 가로채면서* httpx URL 파서가 IPv6 프록시 호스트를 못 읽어 LLM/Embedding/LogAnalyzer 호출이 모두 깨지고 있었다.

결과적으로 PR4 게이트의 LLM 단계가 항상 실패 → 모든 토픽이 stack-only 25점에 머물러 `/hopen-brief/run` 이 항상 `no_eligible_topics` 로 종료.

## 변경
| 파일 | 변경 |
|---|---|
| `app/synthesis/ollama_client.py` | `httpx.Client(trust_env=False)` |
| `app/rag/embedder.py` | `httpx.Client(trust_env=False)` (2곳) |
| `app/ingestion/connectors/loganalyzer.py` | `httpx.Client(timeout=30.0, trust_env=False)` |

외부 인터넷 호출(Google News RSS, og:image 추출)은 의도적으로 건드리지 않음 — 프록시 경로가 정상이라면 그쪽에선 유효.

## Test plan
- [x] 기존 테스트 94 passed
- [ ] 머지 후 prod 재배포 → `/api/v1/insight/hopen-brief/run` dry-run 호출
- [ ] 로그에서 `evaluate_topic` 의 LLM 호출 성공 여부 확인 (filtered_out 사유가 `stack-low` 가 아닌 실제 LLM 점수 기반인지)
- [ ] `eligible >= 1` 인 토픽이 나오는지 확인 (HopenVision 적합도 60+ 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)