### PR TITLE
fix(infra): 외부 fetch 도 trust_env=False (PR9)

### DIFF
--- a/app/services/article_image_extractor.py
+++ b/app/services/article_image_extractor.py
@@ -115,6 +115,9 @@ def extract_article_meta(
         return ArticleMeta(url=url or "", error="invalid url")
 
     sess = session or requests.Session()
+    if session is None:
+        # 신규 세션이면 OrbStack 자동 주입 proxy 우회 — IPv6 resolve 깨짐 회피.
+        sess.trust_env = False
     try:
         resp = sess.get(
             url,
@@ -162,6 +165,7 @@ def extract_many(
     if not urls:
         return out
     with requests.Session() as sess:
+        sess.trust_env = False  # 호스트 proxy 자동 주입 우회
         for url in urls[:limit]:
             out.append(extract_article_meta(url, timeout=timeout, session=sess))
     return out

--- a/app/services/tech_news_search.py
+++ b/app/services/tech_news_search.py
@@ -104,11 +104,14 @@ class GoogleNewsRSS:
         try:
             # feedparser 는 자체 fetch 도 가능하나 timeout 제어가 까다로워
             # requests 로 받아 string 을 파싱한다.
-            resp = requests.get(
-                url,
-                timeout=timeout,
-                headers={"User-Agent": "StandUp-TechTrend/1.0"},
-            )
+            # trust_env=False — OrbStack 자동 주입 proxy 가 IPv6 resolve 깨짐 회피.
+            with requests.Session() as sess:
+                sess.trust_env = False
+                resp = sess.get(
+                    url,
+                    timeout=timeout,
+                    headers={"User-Agent": "StandUp-TechTrend/1.0"},
+                )
             resp.raise_for_status()
             feed = feedparser.parse(resp.text)
         except Exception as e:  # noqa: BLE001 — 외부 장애 흡수
@@ -140,6 +143,9 @@ class NaverNewsAPI:
         self.client_id = client_id
         self.client_secret = client_secret
         self._session = requests.Session()
+        # OrbStack 자동 주입 proxy 우회 — Naver API 호출은 외부 인터넷이지만
+        # 컨테이너의 HTTPS_PROXY 가 IPv6 깨짐을 유발하므로 직접 호출.
+        self._session.trust_env = False
         self._session.headers.update({
             "X-Naver-Client-Id": client_id,
             "X-Naver-Client-Secret": client_secret,


### PR DESCRIPTION
## Summary
PR8 후속 hotfix. PR7 검증에서 case_studies=0 으로 사례 카드가 비어 발견된 회귀. OrbStack 자동 주입 HTTPS_PROXY 가 *외부 인터넷 호출까지* IPv6 resolve 깨짐을 유발.

## 변경
| 파일 | 변경 |
|---|---|
| `app/services/tech_news_search.py` | GoogleNewsRSS.search 가 Session(trust_env=False) 사용 / NaverNewsAPI._session.trust_env=False |
| `app/services/article_image_extractor.py` | 신규 세션에 `sess.trust_env = False` (외부 주입 세션은 호출자 책임) |

테스트 94 passed 그대로.

## Test plan
- [ ] 머지 후 prod 재배포 → dry-run 재호출
- [ ] hopenvision_proposals.case_studies JSON 길이가 0보다 큰지 확인
- [ ] 통과 토픽의 메일 HTML 미리보기에서 사례 카드(썸네일+제목) 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)