### PR TITLE
feat(hopen-brief): /hopen-brief/run 에 force_refresh + max_topics (PR10)

### DIFF
--- a/app/agents_v2/hopen_tech_brief.py
+++ b/app/agents_v2/hopen_tech_brief.py
@@ -188,6 +188,8 @@ def run_daily(
     dry_run: bool = False,
     window_hours: Optional[int] = None,
     skip_ingest: bool = False,
+    force_refresh: bool = False,
+    max_topics: Optional[int] = None,
 ) -> DailyBriefResult:
     """일일 HopenTechBrief 1회 실행.
 
@@ -195,6 +197,9 @@ def run_daily(
         dry_run: True 면 메일 발송 없음 (DB 행은 저장).
         window_hours: 최근 N시간. None 이면 settings.hopen_brief_window_hours.
         skip_ingest: True 면 IngestionHub 호출을 건너뛴다 (이미 다른 곳에서 돌린 경우).
+        force_refresh: True 면 hopenvision_proposals 캐시 무시하고 LLM 재호출 (PR10).
+        max_topics: None 이면 settings.hopen_brief_max_per_day. 운영자가 한 번에
+            더 많은 토픽을 평가해보고 싶을 때 사용 (PR10).
     """
     wh = window_hours if window_hours is not None else settings.hopen_brief_window_hours
     today_kst = now_kst().date()
@@ -220,13 +225,15 @@ def run_daily(
                 len(events), len(tech_topics))
 
     # 3) 게이트 + detailer + (옵션) DevPlan
+    effective_max = max_topics if max_topics is not None else settings.hopen_brief_max_per_day
     proposals: list[ProposalResult]
     with SessionLocal() as session:
         proposals = propose_from_tech_topics(
             session,
             tech_topics,
             auto_dev_plan=settings.tech_trend_auto_dev_plan,
-            max_topics=settings.hopen_brief_max_per_day,
+            max_topics=effective_max,
+            force=force_refresh,
         )
 
     filtered_out = sum(1 for p in proposals if p.status == "filtered_out")

--- a/app/api/v1/endpoints/insight.py
+++ b/app/api/v1/endpoints/insight.py
@@ -150,6 +150,9 @@ class HopenBriefRunRequest(BaseModel):
     dry_run: bool = False
     window_hours: Optional[int] = None
     skip_ingest: bool = False
+    # PR10 — 운영자 수동 트리거 시 캐시·평가 범위 조정.
+    force_refresh: bool = False  # hopenvision_proposals 캐시 무시
+    max_topics: Optional[int] = None  # 1회 평가 토픽 상한 (기본 settings.hopen_brief_max_per_day)
 
 
 class HopenBriefRunResponse(BaseModel):
@@ -165,11 +168,17 @@ class HopenBriefRunResponse(BaseModel):
 
 @router.post("/hopen-brief/run", response_model=HopenBriefRunResponse)
 def trigger_hopen_brief(req: HopenBriefRunRequest):
-    """HopenTechBrief 일일 1회 즉시 실행 (수동 트리거 / dry-run)."""
+    """HopenTechBrief 일일 1회 즉시 실행 (수동 트리거 / dry-run).
+
+    `force_refresh=true` 면 토픽 캐시(`hopenvision_proposals`) 를 무시하고 LLM 재호출.
+    `max_topics` 로 1회 평가 토픽 상한 조정 (기본 `HOPEN_BRIEF_MAX_PER_DAY=3`).
+    """
     res = run_daily_hopen_tech(
         dry_run=req.dry_run,
         window_hours=req.window_hours,
         skip_ingest=req.skip_ingest,
+        force_refresh=req.force_refresh,
+        max_topics=req.max_topics,
     )
     return HopenBriefRunResponse(
         newsletter_id=res.newsletter_id,


### PR DESCRIPTION
운영 적용 검증 중 발견 — 수동 트리거 시 캐시 우회 + 평가 범위 확장 두 옵션이 필요했다.

- POST /api/v1/insight/hopen-brief/run body 에 `force_refresh: bool = false`, `max_topics: int | null` 추가.
- 기본값 유지 시 일일 cron 동작 영향 없음.
- 테스트 94 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)