### PR TITLE
feat(medium-digest-v2): importance_score + interpretation 흡수·노출 (PR-SU-11)

### DIFF
--- a/app/agents_v2/hopen_tech_brief.py
+++ b/app/agents_v2/hopen_tech_brief.py
@@ -130,6 +130,13 @@ def _proposals_to_template_topics(
             digest_title = t.digest_title
             digest_summary = t.digest_summary
 
+        # PR-SU-11 — medium-digest v2 필드를 카드에 동봉.
+        importance_score = t.importance_score if t else None
+        importance_factors = (t.importance_factors if t else []) or []
+        interpretation_core = (t.interpretation_core if t else "") or ""
+        interpretation_why = (t.interpretation_why if t else "") or ""
+        interpretation_takeaways = (t.interpretation_takeaways if t else []) or []
+
         cards.append({
             "keyword": display_keyword,
             "priority": (None
@@ -147,6 +154,12 @@ def _proposals_to_template_topics(
             "code_hints": p.code_hints or [],
             "candidate_modules": p.candidate_modules or [],
             "risks": p.risks or [],
+            # PR-SU-11
+            "importance_score": importance_score,
+            "importance_factors": importance_factors,
+            "interpretation_core": interpretation_core,
+            "interpretation_why": interpretation_why,
+            "interpretation_takeaways": interpretation_takeaways,
         })
     return cards
 

--- a/app/ingestion/connectors/tech_trend.py
+++ b/app/ingestion/connectors/tech_trend.py
@@ -136,6 +136,12 @@ class TechTrendConnector(Connector):
             "risks": report.risks,
             "pilot_scope": report.pilot_scope,
             "file_path": str(report.file_path),
+            # PR-SU-11 — medium-digest-agent v2 새 필드
+            "importance_score": report.importance_score,
+            "importance_factors": report.importance_factors,
+            "interpretation_core": report.interpretation_core,
+            "interpretation_why": report.interpretation_why,
+            "interpretation_takeaways": report.interpretation_takeaways,
         }
 
         return CanonicalEvent(

--- a/app/services/medium_digest_reader.py
+++ b/app/services/medium_digest_reader.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 
 _FILENAME_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})-(.+)\.md$")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
-_BULLET_KV_RE = re.compile(r"^[-*]\s*\*\*(?P<key>[^:*]+)\*\*\s*[:：]\s*(?P<value>.+)$")
+_BULLET_KV_RE = re.compile(r"^[-*]\s*\*\*(?P<key>[^:*]+)\*\*\s*[:：]\s*(?P<value>.*)$")
 _HEADING_RE = re.compile(r"^(#{1,6})\s*(.+?)\s*$")
 
 # 섹션 별칭 — 한글 표기 흔들림 흡수용
@@ -76,6 +76,8 @@ _SECTION_ALIASES = {
     "리스크": "risks",
     "파일럿 적용 범위": "pilot_scope",
     "승인": "approval",
+    # PR-MDA-3 (medium-digest-agent) — 제목 의미 해석 섹션
+    "제목 의미 해석": "interpretation",
 }
 
 # 메타데이터 키 별칭
@@ -87,7 +89,23 @@ _META_KEY_ALIASES = {
     "우선순위": "priority",
     "도입 난이도": "difficulty",
     "기술 성숙도": "maturity",
+    # PR-MDA-2 (medium-digest-agent) — 중요도 점수
+    "중요도 점수": "importance_score",
+    "점수 근거": "importance_factors_block",
 }
+
+# PR-MDA-3 — 제목 의미 해석 섹션 내부의 sub-bullet 키
+_INTERPRETATION_KEY_ALIASES = {
+    "핵심 메시지": "core_message",
+    "왜 지금 화제인가": "why_now",
+    "왜 지금 화제": "why_now",
+    "개발자 Take-away": "takeaways_block",
+    "개발자 take-away": "takeaways_block",
+    "Take-away": "takeaways_block",
+}
+
+# "85/100" 또는 "85" 형태에서 숫자 추출
+_SCORE_RE = re.compile(r"(\d{1,3})")
 
 
 @dataclass
@@ -113,6 +131,13 @@ class DigestReport:
     risks: str = ""
     pilot_scope: str = ""
     raw_text: str = ""
+    # PR-MDA-2 (medium-digest-agent) — 중요도 점수
+    importance_score: Optional[int] = None      # 0~100
+    importance_factors: list[str] = field(default_factory=list)
+    # PR-MDA-3 (medium-digest-agent) — 제목 의미 해석
+    interpretation_core: str = ""               # 핵심 메시지
+    interpretation_why: str = ""                # 왜 지금 화제인가
+    interpretation_takeaways: list[str] = field(default_factory=list)
 
     @property
     def occurred_at(self) -> datetime:
@@ -130,18 +155,104 @@ class DigestReport:
         return (body[:240] + "…") if len(body) > 240 else body
 
 
-def _parse_summary_bullets(lines: list[str]) -> dict[str, str]:
+def _parse_summary_bullets(lines: list[str]) -> tuple[dict[str, str], list[str]]:
+    """요약 섹션 bullet 파싱.
+
+    Returns:
+      (meta_dict, importance_factors)
+      - meta_dict: _META_KEY_ALIASES 매핑 통과한 key/value
+      - importance_factors: '- 점수 근거:' 다음에 들여쓰기로 나열된 sub-bullet 목록.
+        PR-MDA-2 출력 포맷 예:
+            - **점수 근거**:
+              - 채택 가속 ...
+              - 패턴 매칭 ...
+    """
     out: dict[str, str] = {}
+    factors: list[str] = []
+    in_factors_block = False
     for line in lines:
-        m = _BULLET_KV_RE.match(line.strip())
-        if not m:
+        stripped = line.strip()
+        # 1) "- **키**: 값" 형태
+        m = _BULLET_KV_RE.match(stripped)
+        if m:
+            key = m.group("key").strip()
+            value = m.group("value").strip()
+            canonical = _META_KEY_ALIASES.get(key)
+            if canonical == "importance_factors_block":
+                in_factors_block = True
+                # 같은 줄에 값이 있다면 첫 factor 로 흡수 (희귀 케이스)
+                if value:
+                    factors.append(value)
+                continue
+            in_factors_block = False
+            if canonical:
+                out[canonical] = value
             continue
-        key = m.group("key").strip()
-        value = m.group("value").strip()
-        canonical = _META_KEY_ALIASES.get(key)
-        if canonical:
-            out[canonical] = value
-    return out
+        # 2) factors block 안에서 들여쓴 sub-bullet "  - text"
+        if in_factors_block and stripped.startswith("- "):
+            factors.append(stripped[2:].strip())
+            continue
+        # 3) 빈 줄은 block 종료 X (계속 sub-bullet 가능), 다른 형태가 오면 종료
+        if in_factors_block and stripped and not stripped.startswith("- "):
+            in_factors_block = False
+    return out, factors
+
+
+def _parse_score(raw: str) -> Optional[int]:
+    """`85/100` 또는 `85` → 85. 범위 초과는 [0,100] 으로 clamp."""
+    if not raw:
+        return None
+    m = _SCORE_RE.search(raw)
+    if not m:
+        return None
+    try:
+        n = int(m.group(1))
+    except ValueError:
+        return None
+    return max(0, min(100, n))
+
+
+def _parse_interpretation(lines: list[str]) -> tuple[str, str, list[str]]:
+    """제목 의미 해석 섹션 파싱.
+
+    PR-MDA-3 출력 포맷:
+        ## 제목 의미 해석
+        **핵심 메시지**: ...
+        **왜 지금 화제인가**: ...
+        **개발자 Take-away**:
+        - ...
+        - ...
+
+    Returns: (core_message, why_now, takeaways)
+    """
+    core_message = ""
+    why_now = ""
+    takeaways: list[str] = []
+    in_takeaways = False
+    for line in lines:
+        stripped = line.strip()
+        # **key**: value 형태 (선두에 - 가 없을 수도)
+        m = re.match(r"^[-*]?\s*\*\*(?P<key>[^*]+)\*\*\s*[:：]?\s*(?P<value>.*)$", stripped)
+        if m:
+            key = m.group("key").strip()
+            value = m.group("value").strip()
+            canonical = _INTERPRETATION_KEY_ALIASES.get(key)
+            if canonical == "core_message":
+                core_message = value
+                in_takeaways = False
+            elif canonical == "why_now":
+                why_now = value
+                in_takeaways = False
+            elif canonical == "takeaways_block":
+                in_takeaways = True
+                if value:
+                    takeaways.append(value)
+            else:
+                in_takeaways = False
+            continue
+        if in_takeaways and stripped.startswith("- "):
+            takeaways.append(stripped[2:].strip())
+    return core_message, why_now, takeaways
 
 
 def _parse_reference_links(lines: list[str]) -> list[dict[str, str]]:
@@ -209,8 +320,12 @@ def parse_report(file_path: Path) -> Optional[DigestReport]:
         return None
 
     title, sections = _split_sections(text)
-    summary_meta = _parse_summary_bullets(sections.get("summary", []))
+    summary_meta, importance_factors = _parse_summary_bullets(sections.get("summary", []))
     refs = _parse_reference_links(sections.get("references", []))
+    importance_score = _parse_score(summary_meta.get("importance_score", ""))
+    core_msg, why_now, takeaways = _parse_interpretation(
+        sections.get("interpretation", []),
+    )
 
     return DigestReport(
         file_path=file_path,
@@ -232,6 +347,11 @@ def parse_report(file_path: Path) -> Optional[DigestReport]:
         risks=_join(sections.get("risks", [])),
         pilot_scope=_join(sections.get("pilot_scope", [])),
         raw_text=text,
+        importance_score=importance_score,
+        importance_factors=importance_factors,
+        interpretation_core=core_msg,
+        interpretation_why=why_now,
+        interpretation_takeaways=takeaways,
     )
 
 

--- a/app/services/tech_topic_filter.py
+++ b/app/services/tech_topic_filter.py
@@ -140,6 +140,16 @@ def _build_llm_prompt(topic: "TechTopic", repo_summary: str) -> str:
         parts.append(f"적용 대상(외부 예시): {topic.digest_target_scope[:300]}")
     if topic.digest_category:
         parts.append(f"카테고리: {topic.digest_category}")
+    # PR-SU-11 — medium-digest-agent 가 제공하는 한국어 의미 해석을 LLM 컨텍스트로 첨부.
+    # 영어 제목을 가공한 결과라 게이트 LLM 이 적합성 판단을 정확히 한다.
+    if topic.interpretation_core:
+        parts.append(f"핵심 메시지: {topic.interpretation_core}")
+    if topic.interpretation_why:
+        parts.append(f"왜 화제: {topic.interpretation_why}")
+    if topic.interpretation_takeaways:
+        parts.append("Take-away: " + " / ".join(topic.interpretation_takeaways[:3]))
+    if topic.importance_score is not None:
+        parts.append(f"외부 중요도(0~100): {topic.importance_score}")
     if topic.news_articles:
         parts.append("관련 뉴스:")
         for art in topic.news_articles[:3]:

--- a/app/synthesis/pipeline.py
+++ b/app/synthesis/pipeline.py
@@ -50,6 +50,12 @@ class TechTopic:
     digest_url: str = ""
     digest_event_id: str = ""
     news_articles: list[dict] = field(default_factory=list)
+    # PR-SU-11 — medium-digest-agent v2 새 필드 (없으면 비어있음, 안전 default).
+    importance_score: Optional[int] = None
+    importance_factors: list[str] = field(default_factory=list)
+    interpretation_core: str = ""
+    interpretation_why: str = ""
+    interpretation_takeaways: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -273,6 +279,19 @@ def _collect_tech_topics(events: list[IngestionEvent]) -> list[TechTopic]:
             topic.digest_risks = (c.get("risks") or "")[:600]
             topic.digest_url = digest_ev.source_url or ""
             topic.digest_event_id = str(digest_ev.id)
+            # PR-SU-11 — v2 필드 (medium-digest-agent PR-MDA-2/3 산출). canonical 에
+            # 없을 수도 있으므로 안전 fallback.
+            score_raw = c.get("importance_score")
+            if isinstance(score_raw, (int, float)):
+                topic.importance_score = int(score_raw)
+            factors = c.get("importance_factors") or []
+            if isinstance(factors, list):
+                topic.importance_factors = [str(f)[:200] for f in factors[:5]]
+            topic.interpretation_core = (c.get("interpretation_core") or "")[:600]
+            topic.interpretation_why = (c.get("interpretation_why") or "")[:400]
+            takeaways = c.get("interpretation_takeaways") or []
+            if isinstance(takeaways, list):
+                topic.interpretation_takeaways = [str(t)[:200] for t in takeaways[:4]]
         for nev in news_evs:
             nc = nev.canonical or {}
             topic.news_articles.append({

--- a/app/templates/hopen_tech_brief.html
+++ b/app/templates/hopen_tech_brief.html
@@ -73,6 +73,17 @@
                        white-space: pre; }
 
   .empty { color: #8c959f; font-size: 12px; font-style: italic; }
+
+  /* PR-SU-11 — medium-digest v2 박스 */
+  .interp { background: #fff8e1; border-left: 3px solid #fbbf24; padding: 10px 14px;
+            margin: 10px 0 4px; border-radius: 0 6px 6px 0; }
+  .interp-row { font-size: 13px; margin: 3px 0; color: #1f2328; }
+  .interp-row b { color: #92400e; }
+  .interp ul { margin: 4px 0 2px 0; padding-left: 20px; font-size: 12.5px; color: #57606a; }
+  .importance-row { font-size: 12px; color: #6e7781; margin-top: 4px; }
+  .importance-row b { color: #1f2328; }
+  .importance-factors { font-size: 11.5px; color: #57606a; margin: 2px 0 0 0;
+                        padding-left: 14px; }
 </style>
 </head>
 <body>
@@ -113,6 +124,37 @@
       {% endif %}
       {% if t.digest_summary %}
       <div class="topic-target">{{ t.digest_summary }}</div>
+      {% endif %}
+
+      {# PR-SU-11 — 원문 제목 의미 해석 (medium-digest-agent PR-MDA-3) #}
+      {% if t.interpretation_core or t.interpretation_why or t.interpretation_takeaways %}
+      <div class="interp">
+        {% if t.interpretation_core %}
+        <div class="interp-row"><b>핵심 메시지</b>: {{ t.interpretation_core }}</div>
+        {% endif %}
+        {% if t.interpretation_why %}
+        <div class="interp-row"><b>왜 지금 화제</b>: {{ t.interpretation_why }}</div>
+        {% endif %}
+        {% if t.interpretation_takeaways %}
+        <div class="interp-row"><b>Take-away</b></div>
+        <ul>
+          {% for ta in t.interpretation_takeaways %}<li>{{ ta }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+      {% endif %}
+
+      {# PR-SU-11 — 외부 중요도 점수 (medium-digest-agent PR-MDA-2) #}
+      {% if t.importance_score %}
+      <div class="importance-row">
+        외부 중요도 <b>{{ t.importance_score }}/100</b>
+        {% if t.importance_factors %}<span>· 근거:</span>{% endif %}
+        {% if t.importance_factors %}
+        <ul class="importance-factors">
+          {% for f in t.importance_factors %}<li>{{ f }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+      </div>
       {% endif %}
 
       {% if t.diagnosis %}

--- a/tests/test_hopen_tech_brief.py
+++ b/tests/test_hopen_tech_brief.py
@@ -121,6 +121,47 @@ def test_render_handles_no_topics():
     assert "통과 0" in rendered["html"] or "임계치" in rendered["html"]
 
 
+def test_render_includes_v2_interpretation_and_importance():
+    """PR-SU-11 — interpretation 박스 + 외부 중요도 점수 노출 검증."""
+    topics = [TechTopic(
+        keyword="Spring Boot REST Clients",
+        digest_title="[Spring Boot REST Clients] 적용 제안",
+        digest_summary="외부 호출 단순화",
+        importance_score=78,
+        importance_factors=["mainstream 채택", "api 직접 매핑"],
+        interpretation_core="RestClient 도입으로 호출 단순화.",
+        interpretation_why="Spring 6+ stable 이후 확산.",
+        interpretation_takeaways=[
+            "RestTemplate → RestClient 마이그레이션",
+            "fluent 가독성 향상",
+        ],
+    )]
+    proposals = [
+        ProposalResult(
+            proposal_id="p1",
+            cluster_key="tech:spring-boot-rest-clients",
+            diagnosis="d", candidate_modules=[], risks=[], priority="medium",
+            model="m", eval_ms=0, status="generated", raw_response=None,
+            fitness_score=60, impact_area="backend-api", effort_hours=20,
+        ),
+    ]
+    rendered = render_hopen_tech_brief(
+        proposals, topics, period=date(2026, 5, 12),
+        eligible=1, filtered_out=0,
+    )
+    html = rendered["html"]
+    # interpretation 박스
+    assert "핵심 메시지" in html
+    assert "RestClient 도입으로 호출 단순화" in html
+    assert "왜 지금 화제" in html
+    assert "Take-away" in html
+    assert "fluent 가독성 향상" in html
+    # 외부 중요도
+    assert "외부 중요도" in html
+    assert "78/100" in html
+    assert "mainstream 채택" in html
+
+
 # ── run_daily 통합 (DB·LLM·hub·mail 모킹) ───────────────────────────────
 
 def _fake_event(source_type="medium_digest_report"):

--- a/tests/test_medium_digest_reader_v2.py
+++ b/tests/test_medium_digest_reader_v2.py
@@ -1,0 +1,153 @@
+"""medium-digest-agent v2 출력 포맷 파싱 단위 테스트 (PR-SU-11).
+
+PR-MDA-2 (importance_score + factors), PR-MDA-3 (interpretation 섹션) 가 추가한
+markdown 필드를 MediumDigestReaderService.parse_report 가 정상 흡수하는지 검증.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services.medium_digest_reader import parse_report
+
+
+V2_REPORT = """\
+# [Spring Boot REST Clients] 적용 제안 — hopenvision
+
+## 요약
+- **기술 키워드**: Spring Boot REST Clients
+- **카테고리**: api-design
+- **출처 뉴스레터**: Spring Boot 4 Just Made REST Calls Super Easy!
+- **분석일**: 2026-05-12
+- **우선순위**: medium
+- **도입 난이도**: low
+- **기술 성숙도**: mainstream
+- **중요도 점수**: 78/100
+- **점수 근거**:
+  - mainstream 채택, Spring Boot 4 정식 발표
+  - api 도메인 직접 매핑 가능
+  - 학습 곡선 낮음
+  - 기존 RestTemplate 마이그레이션 부담 일부 존재
+
+## 제목 의미 해석
+**핵심 메시지**: Spring Boot 4 가 RestClient 도입으로 REST 호출 코드를 단순화한다.
+**왜 지금 화제인가**: Spring 6+ stable 이후 신규 RestClient API 가 RestTemplate 대안으로 확산.
+**개발자 Take-away**:
+- RestTemplate → RestClient 마이그레이션 패턴 익히기
+- 새 API 의 fluent 방식이 가독성·테스트 용이성 향상
+- WebClient 와 다른 선택 기준 이해
+
+## 참고 자료
+- [Spring 4 RestClient Guide - spring.io](https://spring.io/blog/rc)
+
+## 기술 설명
+Spring Boot 4 의 RestClient 는 ...
+
+## 적용 대상
+| 모듈 | 변경 |
+
+## 변경 사항
+...
+
+## 리스크 및 롤백 전략
+...
+"""
+
+
+V1_REPORT = """\
+# [Java 21+] 적용 제안 — academy-admin/backend
+
+## 요약
+- **기술 키워드**: Java 21+
+- **카테고리**: language-features
+- **출처 뉴스레터**: Java 25 ...
+- **분석일**: 2026-04-13
+- **우선순위**: medium
+- **도입 난이도**: medium
+- **기술 성숙도**: mainstream
+
+## 참고 자료
+- [Oracle Releases Java 26](https://news.google.com/foo)
+
+## 기술 설명
+Java 21은 ...
+
+## 리스크 및 롤백 전략
+- 호환성 이슈
+"""
+
+
+@pytest.fixture()
+def v2_file(tmp_path: Path) -> Path:
+    p = tmp_path / "2026-05-12-spring-boot-rest-clients.md"
+    p.write_text(V2_REPORT, encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def v1_file(tmp_path: Path) -> Path:
+    p = tmp_path / "2026-04-13-java-21.md"
+    p.write_text(V1_REPORT, encoding="utf-8")
+    return p
+
+
+def test_parses_importance_score_and_factors(v2_file):
+    r = parse_report(v2_file)
+    assert r is not None
+    assert r.importance_score == 78
+    assert len(r.importance_factors) == 4
+    assert r.importance_factors[0].startswith("mainstream")
+
+
+def test_parses_interpretation_section(v2_file):
+    r = parse_report(v2_file)
+    assert r is not None
+    assert "RestClient" in r.interpretation_core
+    assert "Spring 6" in r.interpretation_why
+    assert len(r.interpretation_takeaways) == 3
+    assert any("마이그레이션" in t for t in r.interpretation_takeaways)
+
+
+def test_v1_report_keeps_new_fields_empty(v1_file):
+    """PR-MDA-2/3 이전 포맷 — 신규 필드는 None/빈 리스트/빈 문자열."""
+    r = parse_report(v1_file)
+    assert r is not None
+    assert r.keyword == "Java 21+"
+    assert r.importance_score is None
+    assert r.importance_factors == []
+    assert r.interpretation_core == ""
+    assert r.interpretation_why == ""
+    assert r.interpretation_takeaways == []
+
+
+def test_score_clamps_out_of_range(tmp_path):
+    body = V2_REPORT.replace("78/100", "250")
+    p = tmp_path / "2026-05-12-out.md"
+    p.write_text(body, encoding="utf-8")
+    r = parse_report(p)
+    assert r.importance_score == 100
+
+
+def test_score_handles_missing_slash(tmp_path):
+    """'85' 처럼 /100 없는 형식도 흡수."""
+    body = V2_REPORT.replace("78/100", "85")
+    p = tmp_path / "2026-05-12-noslash.md"
+    p.write_text(body, encoding="utf-8")
+    r = parse_report(p)
+    assert r.importance_score == 85
+
+
+def test_interpretation_handles_partial(tmp_path):
+    """interpretation 섹션 중 일부 필드만 있어도 안전."""
+    body = V2_REPORT.replace(
+        "**왜 지금 화제인가**: Spring 6+ stable 이후 신규 RestClient API 가 RestTemplate 대안으로 확산.\n",
+        "",
+    )
+    p = tmp_path / "2026-05-12-partial.md"
+    p.write_text(body, encoding="utf-8")
+    r = parse_report(p)
+    assert r.interpretation_core != ""
+    assert r.interpretation_why == ""
+    assert len(r.interpretation_takeaways) == 3

--- a/tests/test_tech_topic_synthesis.py
+++ b/tests/test_tech_topic_synthesis.py
@@ -269,3 +269,54 @@ def test_render_newsletter_does_not_emit_anchor_for_file_url():
     )])
     result = render_newsletter(syn)
     assert "file:///tmp/x.md" not in result["html"]
+
+
+# ── PR-SU-11: medium-digest v2 필드 (_collect_tech_topics 안 전파) ────────
+
+def test_collect_tech_topics_passes_v2_fields_into_topic():
+    """canonical 에 importance_score / interpretation_* 가 있으면 TechTopic 에 흘러야."""
+    ev = FakeEvent(
+        id="dv2",
+        source_type=SOURCE_MEDIUM_DIGEST_REPORT,
+        title="[Spring Boot REST Clients] 적용 제안",
+        occurred_at=datetime(2026, 5, 12, tzinfo=timezone.utc),
+        canonical={
+            "keyword": "Spring Boot REST Clients",
+            "priority": "high",
+            "category": "api-design",
+            "difficulty": "low",
+            "maturity": "mainstream",
+            "tech_description": "Spring Boot 4 의 RestClient ...",
+            "target_scope": "Controllers, services",
+            "risks": "RestTemplate 마이그레이션",
+            # PR-MDA-2/3 새 필드
+            "importance_score": 78,
+            "importance_factors": ["mainstream 채택", "api 직접 매핑"],
+            "interpretation_core": "RestClient 도입으로 호출 단순화.",
+            "interpretation_why": "Spring 6+ stable 이후 확산.",
+            "interpretation_takeaways": [
+                "RestTemplate → RestClient 마이그레이션",
+                "fluent 가독성 향상",
+                "WebClient 와 선택 기준 이해",
+            ],
+        },
+    )
+    topics = _collect_tech_topics([ev])
+    assert len(topics) == 1
+    t = topics[0]
+    assert t.importance_score == 78
+    assert t.importance_factors == ["mainstream 채택", "api 직접 매핑"]
+    assert "RestClient" in t.interpretation_core
+    assert "Spring 6" in t.interpretation_why
+    assert len(t.interpretation_takeaways) == 3
+    assert "마이그레이션" in t.interpretation_takeaways[0]
+
+
+def test_collect_tech_topics_handles_missing_v2_fields_safely():
+    """v2 필드 없는 옛 canonical 도 깨지지 않고 빈 default 로."""
+    ev = _digest_event(keyword="Legacy", title="[Legacy] 적용", event_id="dv1")
+    topics = _collect_tech_topics([ev])
+    assert topics[0].importance_score is None
+    assert topics[0].importance_factors == []
+    assert topics[0].interpretation_core == ""
+    assert topics[0].interpretation_takeaways == []


### PR DESCRIPTION
medium-digest-agent PR-MDA-2/3 가 reports/*.md 에 추가한 두 신규 섹션을 StandUp 이 파싱·전파·카드 노출까지 연결.

## 변경
- `app/services/medium_digest_reader.py` — DigestReport 에 `importance_score / importance_factors / interpretation_core / interpretation_why / interpretation_takeaways` 추가. `_BULLET_KV_RE` 완화로 빈값 헤더 흡수, `_parse_interpretation` 신규.
- `app/ingestion/connectors/tech_trend.py` — canonical 에 v2 필드 5개 보관.
- `app/synthesis/pipeline.py` — TechTopic 확장 + `_collect_tech_topics` 가 안전하게 전파.
- `app/services/tech_topic_filter.py` — 게이트 LLM 입력에 한국어 interpretation 첨부 (영어 제목 ambiguity 해소).
- `app/agents_v2/hopen_tech_brief.py` + `app/templates/hopen_tech_brief.html` — 카드에 "제목 의미 해석" 박스 + "외부 중요도 N/100 + 근거" 표시.
- 테스트 103 passed (신규 9 + 기존 94).

## 실파일 smoke
`reports/2026-05-12-virtual-threads.md` (PR-MDA 산출) 파싱 → score=85, factors 3개, interpretation fallback 문구 정상 흡수. v1 (PR-MDA 이전) reports 도 backward compat 통과.

## 다음
- 머지 후 prod 머지로 운영 재배포 → dry-run 으로 카드에 두 박스 노출 확인.
- (별도) PR-MDA-3 fallback 빈도 높음 → medium-digest-agent 측 title-interpreter 프롬프트 보강을 향후 PR-MDA-5 로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)